### PR TITLE
Add panning, zoom, and resize support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Run the script below to download them into the `assets/` directory:
 
 Once downloaded, you can build and run the viewer normally.
 
+The viewer now opens at **1280x720** and supports window resizing. Use the
+arrow or **WASD** keys or drag with the mouse to pan, and the mouse wheel or
+`+`/`-` keys to zoom.
+


### PR DESCRIPTION
## Summary
- scale and translate geyser data so the origin is at the bottom-right and the map is magnified
- support panning and zooming with mouse or keyboard
- resize the window dynamically and start at 1280x720
- document new controls

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68663d18c01c832a82c0d5baad45ca78