### PR TITLE
Fix vector fill rule for biome rendering

### DIFF
--- a/main.go
+++ b/main.go
@@ -385,7 +385,11 @@ func drawPolygon(dst *ebiten.Image, pts []Point, clr color.Color, camX, camY, zo
 		vs[i].ColorB = float32(b) / 0xffff
 		vs[i].ColorA = float32(a) / 0xffff
 	}
-	op := &ebiten.DrawTrianglesOptions{AntiAlias: true, ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha}
+	op := &ebiten.DrawTrianglesOptions{
+		AntiAlias:      true,
+		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
+		FillRule:       ebiten.FillRuleEvenOdd,
+	}
 	dst.DrawTriangles(vs, is, whitePixel, op)
 }
 
@@ -417,7 +421,11 @@ func drawBiome(dst *ebiten.Image, polys [][]Point, clr color.Color, camX, camY, 
 		vs[i].ColorB = float32(b) / 0xffff
 		vs[i].ColorA = float32(a) / 0xffff
 	}
-	op := &ebiten.DrawTrianglesOptions{AntiAlias: true, ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha}
+	op := &ebiten.DrawTrianglesOptions{
+		AntiAlias:      true,
+		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
+		FillRule:       ebiten.FillRuleEvenOdd,
+	}
 	dst.DrawTriangles(vs, is, whitePixel, op)
 }
 


### PR DESCRIPTION
## Summary
- enable even-odd fill rule when drawing biome polygons
- apply same rule for single polygon rendering

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866be391ba4832aa9cb3f987dcfa147