### PR TITLE
Fix polygon anti-aliasing

### DIFF
--- a/main.go
+++ b/main.go
@@ -389,7 +389,7 @@ func drawPolygon(dst *ebiten.Image, pts []Point, clr color.Color, camX, camY, zo
 	}
 	op := &ebiten.DrawTrianglesOptions{
 		AntiAlias:      true,
-		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
+		ColorScaleMode: ebiten.ColorScaleModeStraightAlpha,
 		FillRule:       ebiten.FillRuleEvenOdd,
 	}
 	dst.DrawTriangles(vs, is, whitePixel, op)
@@ -425,7 +425,7 @@ func drawBiome(dst *ebiten.Image, polys [][]Point, clr color.Color, camX, camY, 
 	}
 	op := &ebiten.DrawTrianglesOptions{
 		AntiAlias:      true,
-		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
+		ColorScaleMode: ebiten.ColorScaleModeStraightAlpha,
 		FillRule:       ebiten.FillRuleEvenOdd,
 	}
 	dst.DrawTriangles(vs, is, whitePixel, op)


### PR DESCRIPTION
## Summary
- ensure polygons use straight alpha blending when drawn

## Testing
- `go vet ./...`
- `go test ./...` *(fails: GLFW library not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6866c875eaf0832aa7dbfdb946303513