### PR TITLE
Add headless run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ arrow or **WASD** keys or drag with the mouse to pan, and the mouse wheel or
 `+`/`-` keys to zoom. Zooming keeps the center of the screen fixed and the
 icons scale with the current zoom level.
 
+## Running headless
+
+If you need to run the viewer without a physical display, install `Xvfb` and
+use the `run_headless.sh` script:
+
+```bash
+sudo apt-get install xvfb   # one-time setup
+./scripts/run_headless.sh -coord SNDST-A-7-0-0-0
+```
+
+The script uses `xvfb-run` to start a virtual framebuffer so the window can be
+created even on headless machines.
+

--- a/scripts/run_headless.sh
+++ b/scripts/run_headless.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the viewer using a virtual framebuffer.
+# Any arguments passed to this script are forwarded to the Go program.
+
+if ! command -v Xvfb > /dev/null; then
+  echo "Xvfb is required for headless mode" >&2
+  exit 1
+fi
+
+xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go run . "$@"


### PR DESCRIPTION
## Summary
- add `run_headless.sh` script that wraps `xvfb-run`
- document headless setup in README

## Testing
- `xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866cd1147ac832aaae922e4b873dc2c