### PR TITLE
Add headless screenshot test and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: build-and-release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Download assets
+        run: ./scripts/download_assets.sh
+      - name: Run tests
+        run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go test ./...
+      - name: Build binaries
+        run: ./scripts/build_all.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oni-view-builds
+          path: dist/*
+
+  release:
+    needs: test-and-build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: oni-view-builds
+          path: dist
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+

--- a/screenshot_test.go
+++ b/screenshot_test.go
@@ -1,0 +1,26 @@
+//go:build screenshot
+
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestHeadlessScreenshot(t *testing.T) {
+	if _, err := exec.LookPath("xvfb-run"); err != nil {
+		t.Skip("xvfb-run not installed")
+	}
+	if err := os.RemoveAll("screenshot.png"); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("cleanup: %v", err)
+	}
+	cmd := exec.Command("bash", "scripts/run_headless.sh", "-screenshot", "screenshot.png")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run failed: %v\n%s", err, string(out))
+	}
+	if fi, err := os.Stat("screenshot.png"); err != nil || fi.Size() == 0 {
+		t.Fatalf("screenshot not created")
+	}
+}

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p dist
+GOOS=linux GOARCH=amd64 go build -o dist/oni-view-linux-amd64 .
+GOOS=darwin GOARCH=amd64 go build -o dist/oni-view-darwin-amd64 .
+GOOS=darwin GOARCH=arm64 go build -o dist/oni-view-darwin-arm64 .
+GOOS=windows GOARCH=amd64 go build -o dist/oni-view-windows-amd64.exe .
+GOOS=js GOARCH=wasm go build -o dist/oni-view.wasm .
+


### PR DESCRIPTION
## Summary
- capture screenshot when `-screenshot` flag is used
- add an integration test (requires xvfb) to exercise screenshot generation
- add script to build binaries for multiple targets
- create GitHub Actions workflow to run tests and upload cross-platform builds on tag

## Testing
- `xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go test ./...`
- `xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go test -tags=screenshot ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866d05e63c8832a9752b115c3f53871