### PR TITLE
Enhance legends

### DIFF
--- a/const.go
+++ b/const.go
@@ -17,6 +17,7 @@ const (
 	InitialZoom         = 1.0
 	LabelCharWidth      = 6
 	NumberLegendXOffset = 150
+	LegendRowSpacing    = 18
 	ScreenshotFile      = "screenshot.png"
 )
 


### PR DESCRIPTION
## Summary
- use new LegendRowSpacing constant for consistent spacing
- store legend color info for objects
- render object legend with colored frames
- tweak biome legend spacing

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866da522ad0832a9c52efa655a3321a