### PR TITLE
Fix polygon edges by using premultiplied alpha

### DIFF
--- a/main.go
+++ b/main.go
@@ -522,8 +522,8 @@ func drawPolygon(dst *ebiten.Image, pts []Point, clr color.Color, camX, camY, zo
 	for i := range vs {
 		x := float64(vs[i].DstX)*zoom + camX
 		y := float64(vs[i].DstY)*zoom + camY
-		vs[i].DstX = float32(math.Round(x))
-		vs[i].DstY = float32(math.Round(y))
+		vs[i].DstX = float32(x)
+		vs[i].DstY = float32(y)
 		vs[i].SrcX = 0
 		vs[i].SrcY = 0
 		vs[i].ColorR = float32(r) / 0xffff
@@ -533,7 +533,7 @@ func drawPolygon(dst *ebiten.Image, pts []Point, clr color.Color, camX, camY, zo
 	}
 	op := &ebiten.DrawTrianglesOptions{
 		AntiAlias:      true,
-		ColorScaleMode: ebiten.ColorScaleModeStraightAlpha,
+		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
 		FillRule:       ebiten.FillRuleEvenOdd,
 	}
 	dst.DrawTriangles(vs, is, whitePixel, op)
@@ -560,8 +560,8 @@ func drawBiome(dst *ebiten.Image, polys [][]Point, clr color.Color, camX, camY, 
 	for i := range vs {
 		x := float64(vs[i].DstX)*zoom + camX
 		y := float64(vs[i].DstY)*zoom + camY
-		vs[i].DstX = float32(math.Round(x))
-		vs[i].DstY = float32(math.Round(y))
+		vs[i].DstX = float32(x)
+		vs[i].DstY = float32(y)
 		vs[i].SrcX = 0
 		vs[i].SrcY = 0
 		vs[i].ColorR = float32(r) / 0xffff
@@ -571,7 +571,7 @@ func drawBiome(dst *ebiten.Image, polys [][]Point, clr color.Color, camX, camY, 
 	}
 	op := &ebiten.DrawTrianglesOptions{
 		AntiAlias:      true,
-		ColorScaleMode: ebiten.ColorScaleModeStraightAlpha,
+		ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha,
 		FillRule:       ebiten.FillRuleEvenOdd,
 	}
 	dst.DrawTriangles(vs, is, whitePixel, op)


### PR DESCRIPTION
## Summary
- avoid rounding polygon vertices so Ebiten can antialias edges
- switch back to premultiplied alpha when drawing polygons

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`
- `env LIBGL_ALWAYS_SOFTWARE=1 ./scripts/run_headless.sh -screenshot screenshot_after.png` (produced identical screenshot)


------
https://chatgpt.com/codex/tasks/task_e_6866dfdcbbf4832a932b98d245831d48