### PR TITLE
Refine biome visual effects

### DIFF
--- a/main.go
+++ b/main.go
@@ -449,7 +449,7 @@ var tundraPattern = func() *ebiten.Image {
 	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	line := color.RGBA{255, 255, 255, 25}
+	line := color.RGBA{255, 255, 255, 10}
 	for i := 0; i < size; i++ {
 		img.Set(i, size-1-i, line)
 		if i+4 < size {
@@ -463,7 +463,7 @@ var magmaPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	lava := color.RGBA{255, 80, 0, 40}
+	lava := color.RGBA{255, 80, 0, 15}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/3) + 1) * float64(size) / 4)
 		if y < size {
@@ -480,7 +480,7 @@ var oceanPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	wave := color.RGBA{255, 255, 255, 20}
+	wave := color.RGBA{255, 255, 255, 8}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/2) + 1) * float64(size) / 4)
 		if y < size {
@@ -497,7 +497,7 @@ var sandPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	dot := color.RGBA{255, 255, 255, 10}
+	dot := color.RGBA{255, 255, 255, 5}
 	for x := 0; x < size; x++ {
 		for y := 0; y < size; y++ {
 			if (x+y)%8 == 0 {
@@ -512,7 +512,7 @@ var toxicPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	slime := color.RGBA{100, 255, 100, 20}
+	slime := color.RGBA{100, 255, 100, 8}
 	cx, cy := float64(size)/2, float64(size)/2
 	for x := 0; x < size; x++ {
 		for y := 0; y < size; y++ {
@@ -530,7 +530,7 @@ var oilPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	line := color.RGBA{255, 255, 255, 20}
+	line := color.RGBA{255, 255, 255, 8}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/2) + 1) * float64(size) / 4)
 		if y < size {
@@ -544,7 +544,7 @@ var marshPattern = func() *ebiten.Image {
 	const size = 16
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	grass := color.RGBA{255, 255, 255, 15}
+	grass := color.RGBA{255, 255, 255, 7}
 	for x := 0; x < size; x += 5 {
 		for y := 0; y < size; y++ {
 			img.Set(x, y, grass)
@@ -734,7 +734,7 @@ func drawTundraGradient(dst *ebiten.Image, polys [][]Point, camX, camY, zoom flo
 		vs[i].SrcY = 0
 		alpha := float32(0.0)
 		if maxY > minY {
-			alpha = float32(0.3 * (1 - (y-minY)/(maxY-minY)))
+			alpha = float32(0.15 * (1 - (y-minY)/(maxY-minY)))
 		}
 		vs[i].ColorR = 1
 		vs[i].ColorG = 1
@@ -784,6 +784,8 @@ func drawPattern(dst *ebiten.Image, polys [][]Point, camX, camY, zoom float64, p
 		ColorScaleMode: ebiten.ColorScaleModeStraightAlpha,
 		FillRule:       ebiten.FillRuleEvenOdd,
 		Address:        ebiten.AddressRepeat,
+		Filter:         ebiten.FilterLinear,
+		DisableMipmaps: true,
 	}
 	dst.DrawTriangles(vs, is, pattern, op)
 }


### PR DESCRIPTION
## Summary
- tone down biome pattern opacity
- soften tundra gradient effect
- render patterns using linear filtering and no mipmaps to reduce aliasing

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866e53b5cf0832a87c7e8b5e2f9c963