### PR TITLE
Reduce aliasing in biome patterns

### DIFF
--- a/main.go
+++ b/main.go
@@ -449,7 +449,7 @@ var tundraPattern = func() *ebiten.Image {
 	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	line := color.RGBA{255, 255, 255, 10}
+	line := color.RGBA{255, 255, 255, 5}
 	for i := 0; i < size; i++ {
 		img.Set(i, size-1-i, line)
 		if i+4 < size {
@@ -460,47 +460,47 @@ var tundraPattern = func() *ebiten.Image {
 }()
 
 var magmaPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	lava := color.RGBA{255, 80, 0, 15}
+	lava := color.RGBA{255, 80, 0, 8}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/3) + 1) * float64(size) / 4)
 		if y < size {
 			img.Set(x, y, lava)
 		}
-		if y+4 < size {
-			img.Set(x, y+4, lava)
+		if y+8 < size {
+			img.Set(x, y+8, lava)
 		}
 	}
 	return img
 }()
 
 var oceanPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	wave := color.RGBA{255, 255, 255, 8}
+	wave := color.RGBA{255, 255, 255, 4}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/2) + 1) * float64(size) / 4)
 		if y < size {
 			img.Set(x, y, wave)
 		}
-		if y+6 < size {
-			img.Set(x, y+6, wave)
+		if y+12 < size {
+			img.Set(x, y+12, wave)
 		}
 	}
 	return img
 }()
 
 var sandPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	dot := color.RGBA{255, 255, 255, 5}
+	dot := color.RGBA{255, 255, 255, 3}
 	for x := 0; x < size; x++ {
 		for y := 0; y < size; y++ {
-			if (x+y)%8 == 0 {
+			if (x+y)%16 == 0 {
 				img.Set(x, y, dot)
 			}
 		}
@@ -509,10 +509,10 @@ var sandPattern = func() *ebiten.Image {
 }()
 
 var toxicPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	slime := color.RGBA{100, 255, 100, 8}
+	slime := color.RGBA{100, 255, 100, 4}
 	cx, cy := float64(size)/2, float64(size)/2
 	for x := 0; x < size; x++ {
 		for y := 0; y < size; y++ {
@@ -527,10 +527,10 @@ var toxicPattern = func() *ebiten.Image {
 }()
 
 var oilPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	line := color.RGBA{255, 255, 255, 8}
+	line := color.RGBA{255, 255, 255, 4}
 	for x := 0; x < size; x++ {
 		y := int((math.Sin(float64(x)/2) + 1) * float64(size) / 4)
 		if y < size {
@@ -541,11 +541,11 @@ var oilPattern = func() *ebiten.Image {
 }()
 
 var marshPattern = func() *ebiten.Image {
-	const size = 16
+	const size = 32
 	img := ebiten.NewImage(size, size)
 	img.Fill(color.RGBA{0, 0, 0, 0})
-	grass := color.RGBA{255, 255, 255, 7}
-	for x := 0; x < size; x += 5 {
+	grass := color.RGBA{255, 255, 255, 3}
+	for x := 0; x < size; x += 10 {
 		for y := 0; y < size; y++ {
 			img.Set(x, y, grass)
 		}
@@ -785,7 +785,6 @@ func drawPattern(dst *ebiten.Image, polys [][]Point, camX, camY, zoom float64, p
 		FillRule:       ebiten.FillRuleEvenOdd,
 		Address:        ebiten.AddressRepeat,
 		Filter:         ebiten.FilterLinear,
-		DisableMipmaps: true,
 	}
 	dst.DrawTriangles(vs, is, pattern, op)
 }


### PR DESCRIPTION
## Summary
- increase pattern tile sizes and lower the alpha values so biome textures are subtle
- allow mipmaps in `drawPattern` for smoother scaling

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866e702fcc8832abb4687a6aa00b0bf