### PR TITLE
Allow camera to pan off screen

### DIFF
--- a/const.go
+++ b/const.go
@@ -4,9 +4,12 @@ package main
 import "math"
 
 const (
-	BaseURL             = "https://ingest.mapsnotincluded.org/coordinate/"
-	AcceptCBORHeader    = "application/cbor"
-	PanSpeed            = 15
+	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
+	AcceptCBORHeader = "application/cbor"
+	PanSpeed         = 15
+	// CameraMargin controls how far the world can be panned
+	// beyond the visible screen in pixels.
+	CameraMargin        = 64
 	KeyZoomFactor       = 1.05
 	WheelZoomFactor     = 1.1
 	MinZoom             = 0.5

--- a/main.go
+++ b/main.go
@@ -955,17 +955,18 @@ type label struct {
 func (g *Game) clampCamera() {
 	w := float64(g.astWidth) * 2 * g.zoom
 	h := float64(g.astHeight) * 2 * g.zoom
-	if g.camX < -w+1 {
-		g.camX = -w + 1
+	margin := float64(CameraMargin)
+	if g.camX < -w-margin {
+		g.camX = -w - margin
 	}
-	if g.camX > float64(g.width)-1 {
-		g.camX = float64(g.width) - 1
+	if g.camX > float64(g.width)+margin {
+		g.camX = float64(g.width) + margin
 	}
-	if g.camY < -h+1 {
-		g.camY = -h + 1
+	if g.camY < -h-margin {
+		g.camY = -h - margin
 	}
-	if g.camY > float64(g.height)-1 {
-		g.camY = float64(g.height) - 1
+	if g.camY > float64(g.height)+margin {
+		g.camY = float64(g.height) + margin
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `CameraMargin` constant to control panning bounds
- let `clampCamera` use this margin so the world can move fully off screen

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866f5b8b15c832a8cffa560ca1bbc29