### PR TITLE
Fill empty map regions with space color

### DIFF
--- a/main.go
+++ b/main.go
@@ -1072,6 +1072,11 @@ func (g *Game) Update() error {
 func (g *Game) Draw(screen *ebiten.Image) {
 	if g.needsRedraw {
 		screen.Fill(color.RGBA{30, 30, 30, 255})
+		if clr, ok := biomeColors["Space"]; ok {
+			vector.DrawFilledRect(screen, float32(g.camX), float32(g.camY),
+				float32(float64(g.astWidth)*2*g.zoom),
+				float32(float64(g.astHeight)*2*g.zoom), clr, false)
+		}
 		labels := []label{}
 		useNumbers := g.zoom < LegendZoomThreshold
 		if useNumbers && g.legendMap == nil {


### PR DESCRIPTION
## Summary
- draw a light gray background inside the asteroid bounds so empty regions appear as the `Space` biome

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6866f8fcedd0832aa1d063b0846a84dd