### PR TITLE
Fix cross-compiling build script

### DIFF
--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 mkdir -p dist
-GOOS=linux GOARCH=amd64 go build -o dist/oni-view-linux-amd64 .
-GOOS=darwin GOARCH=amd64 go build -o dist/oni-view-darwin-amd64 .
-GOOS=darwin GOARCH=arm64 go build -o dist/oni-view-darwin-arm64 .
-GOOS=windows GOARCH=amd64 go build -o dist/oni-view-windows-amd64.exe .
-GOOS=js GOARCH=wasm go build -o dist/oni-view.wasm .
+env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o dist/oni-view-linux-amd64 .
+env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o dist/oni-view-darwin-amd64 .
+env CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o dist/oni-view-darwin-arm64 .
+env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -o dist/oni-view-windows-amd64.exe .
+env CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -o dist/oni-view.wasm .
 


### PR DESCRIPTION
## Summary
- enable CGO when building for desktop OS targets
- disable CGO for wasm build

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866fc33f3a8832aafbfd3c2e630647e