### PR TITLE
Fix asset download script to handle webp icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Oni View is a small utility for inspecting **Oxygen Not Included** seed data. It
    ./scripts/download_assets.sh
    ```
 
-   After the script completes the PNG images will be placed in the `assets/` directory.
+   The script converts any `.webp` icons to `.png` using `dwebp`. After it completes the
+   PNG files will be placed in the `assets/` directory. Install the `webp` package if needed.
 
 3. **Build and run** – Execute the program with a seed coordinate. The window defaults to 1280×720 but can be resized.
 

--- a/scripts/download_assets.sh
+++ b/scripts/download_assets.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 ASSET_DIR="$(dirname "$0")/../assets"
 TEMP_DIR=$(mktemp -d)
 
-if [ -n "$(ls -A "$ASSET_DIR" 2>/dev/null | grep -v '.gitkeep' || true)" ]; then
-    echo "Assets already exist in $ASSET_DIR"
-    exit 0
+if ! command -v dwebp >/dev/null; then
+    echo "dwebp command not found. Please install the 'webp' package." >&2
+    exit 1
 fi
 
 echo "Cloning ONITraitFinder repository..."
@@ -15,6 +15,10 @@ git clone --depth 1 https://github.com/MapsNotIncluded/ONITraitFinder "$TEMP_DIR
 echo "Copying assets..."
 mkdir -p "$ASSET_DIR"
 find "$TEMP_DIR"/docs/images -name '*.png' -exec cp {} "$ASSET_DIR" \;
+find "$TEMP_DIR"/docs/images -name '*.webp' -print0 | while IFS= read -r -d '' img; do
+    out="$ASSET_DIR/$(basename "${img%.webp}").png"
+    dwebp "$img" -o "$out" >/dev/null
+done
 
 echo "Cleaning up..."
 rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- update asset download script
  - remove existing asset guard
  - convert `.webp` icons to `.png`
  - ensure `dwebp` is installed
- document the new conversion step in README

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6867114baa98832a9c363200151bea52