### PR TITLE
Fix asset download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Oni View is a small utility for inspecting **Oxygen Not Included** seed data. It
    ./scripts/download_assets.sh
    ```
 
-   The script converts any `.webp` icons to `.png` using `dwebp`. After it completes the
-   PNG files will be placed in the `assets/` directory. Install the `webp` package if needed.
+   After the script completes the PNG images will be placed in the `assets/` directory.
 
 3. **Build and run** – Execute the program with a seed coordinate. The window defaults to 1280×720 but can be resized.
 

--- a/main.go
+++ b/main.go
@@ -323,6 +323,11 @@ func loadImage(cache map[string]*ebiten.Image, name string) (*ebiten.Image, erro
 		return nil, err
 	}
 	if nrgba, ok := src.(*image.NRGBA); ok {
+		for i := 3; i < len(nrgba.Pix); i += 4 {
+			if nrgba.Pix[i] < 64 {
+				nrgba.Pix[i] = 0
+			}
+		}
 		img := ebiten.NewImageFromImage(nrgba)
 		cache[name] = img
 		return img, nil
@@ -330,6 +335,11 @@ func loadImage(cache map[string]*ebiten.Image, name string) (*ebiten.Image, erro
 	bounds := src.Bounds()
 	dst := image.NewNRGBA(bounds)
 	draw.Draw(dst, bounds, src, bounds.Min, draw.Src)
+	for i := 3; i < len(dst.Pix); i += 4 {
+		if dst.Pix[i] < 64 {
+			dst.Pix[i] = 0
+		}
+	}
 	img := ebiten.NewImageFromImage(dst)
 	cache[name] = img
 	return img, nil

--- a/scripts/download_assets.sh
+++ b/scripts/download_assets.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 ASSET_DIR="$(dirname "$0")/../assets"
 TEMP_DIR=$(mktemp -d)
 
-if ! command -v dwebp >/dev/null; then
-    echo "dwebp command not found. Please install the 'webp' package." >&2
-    exit 1
+if [ -n "$(ls -A "$ASSET_DIR" 2>/dev/null | grep -v '.gitkeep' || true)" ]; then
+    echo "Assets already exist in $ASSET_DIR"
+    exit 0
 fi
 
 echo "Cloning ONITraitFinder repository..."
@@ -15,10 +15,6 @@ git clone --depth 1 https://github.com/MapsNotIncluded/ONITraitFinder "$TEMP_DIR
 echo "Copying assets..."
 mkdir -p "$ASSET_DIR"
 find "$TEMP_DIR"/docs/images -name '*.png' -exec cp {} "$ASSET_DIR" \;
-find "$TEMP_DIR"/docs/images -name '*.webp' -print0 | while IFS= read -r -d '' img; do
-    out="$ASSET_DIR/$(basename "${img%.webp}").png"
-    dwebp "$img" -o "$out" >/dev/null
-done
 
 echo "Cleaning up..."
 rm -rf "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- download png assets directly instead of converting webp images
- clarify README instructions for asset download
- clean up transparency on loaded images

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68671682fbe8832a8cfc26f600c9454c