### PR TITLE
Add WASM html loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ sudo apt-get install xvfb   # one-time setup
 ./scripts/run_headless.sh -coord SNDST-A-7-0-0-0
 ```
 
+## WebAssembly Build
+
+Run the build script to compile the program and copy the necessary runtime files. The generated WASM binary, runtime JavaScript and `index.html` will be placed in `dist/`.
+
+```bash
+./scripts/build_all.sh
+```
+
+Open `dist/index.html` in a browser to test the WebAssembly build.
+
 ## Repository Layout
 
 ```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Oni View Web</title>
+  <script src="wasm_exec.js"></script>
+  <script>
+    if (!WebAssembly.instantiateStreaming) {
+      WebAssembly.instantiateStreaming = async (resp, importObject) => {
+        const source = await (await resp).arrayBuffer();
+        return await WebAssembly.instantiate(source, importObject);
+      };
+    }
+    const go = new Go();
+    WebAssembly.instantiateStreaming(fetch("oni-view.wasm"), go.importObject).then((result) => {
+      go.run(result.instance);
+    }).catch((err) => {
+      console.error(err);
+    });
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -7,3 +7,7 @@ env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o dist/oni-view-linux-amd64 
 env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -o dist/oni-view-windows-amd64.exe .
 env CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -o dist/oni-view.wasm .
 
+# Copy the JS runtime and HTML loader for WASM builds.
+cp $(go env GOROOT)/lib/wasm/wasm_exec.js dist/
+cp index.html dist/
+


### PR DESCRIPTION
## Summary
- add `index.html` to run the WebAssembly build
- copy wasm runtime and html loader in `build_all.sh`
- document how to test the WASM build in the README

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686720226a4c832aa4bd34798ab1c694