### PR TITLE
Throttle wheel zoom in wasm builds

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,7 +1,10 @@
 // Package constants for configuration.
 package main
 
-import "math"
+import (
+	"math"
+	"time"
+)
 
 const (
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
@@ -22,6 +25,9 @@ const (
 	NumberLegendXOffset = 150
 	LegendRowSpacing    = 25
 	ScreenshotFile      = "screenshot.png"
+	// WheelThrottle controls how often mouse wheel zoom is applied
+	// in WASM to account for faster scroll events.
+	WheelThrottle = 75 * time.Millisecond
 )
 
 var LegendZoomThreshold = math.Pow(WheelZoomFactor, LegendZoomExponent)

--- a/main.go
+++ b/main.go
@@ -18,9 +18,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/hajimehoshi/ebiten/v2"
@@ -1023,6 +1025,7 @@ type Game struct {
 	legendEntries  []string
 	legendColors   []color.RGBA
 	legendImage    *ebiten.Image
+	lastWheel      time.Time
 }
 
 type label struct {
@@ -1142,6 +1145,14 @@ func (g *Game) Update() error {
 
 	// Zoom with mouse wheel
 	_, wheelY := ebiten.Wheel()
+	if runtime.GOARCH == "wasm" && wheelY != 0 {
+		now := time.Now()
+		if now.Sub(g.lastWheel) < WheelThrottle {
+			wheelY = 0
+		} else {
+			g.lastWheel = now
+		}
+	}
 	if wheelY != 0 {
 		if wheelY > 0 {
 			zoomFactor *= WheelZoomFactor


### PR DESCRIPTION
## Summary
- tweak constants to throttle scrolling in WASM
- add lastWheel tracking
- skip mouse wheel zoom events when they occur too rapidly on WebAssembly

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68674c57269c832a97bf21b26e9f948d