### PR TITLE
Load assets via network in WASM build

### DIFF
--- a/const.go
+++ b/const.go
@@ -28,6 +28,11 @@ const (
 	// WheelThrottle controls how often mouse wheel zoom is applied
 	// in WASM to account for faster scroll events.
 	WheelThrottle = 75 * time.Millisecond
+
+	// WebAssetBase specifies the path used to fetch image assets
+	// when running in WebAssembly. The assets should be served
+	// relative to the page URL.
+	WebAssetBase = "assets/"
 )
 
 var LegendZoomThreshold = math.Pow(WheelZoomFactor, LegendZoomExponent)


### PR DESCRIPTION
## Summary
- load `names.json` and icons via helper that uses HTTP when GOOS=js
- add `WebAssetBase` constant
- update asset loading helper functions

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68674de6f130832aab36e512907d660d