### PR TITLE
Optimize wasm bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ sudo apt-get install xvfb   # one-time setup
 
 ## WebAssembly Build
 
-Run the build script to compile the program and copy the necessary runtime files. The generated WASM binary, runtime JavaScript and `index.html` will be placed in `dist/`.
+Run the build script to compile the program and copy the necessary runtime files. The WebAssembly module is optimized and compressed, with the runtime JavaScript and `index.html` placed in `dist/`.
 
 ```bash
 ./scripts/build_all.sh
 ```
 
-Open `dist/index.html` in a browser to test the WebAssembly build.
+Open `dist/index.html` in a browser to test the WebAssembly build. The page loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
 
 ## Repository Layout
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Oni View Web</title>
   <script src="wasm_exec.js"></script>
+  <script src="https://unpkg.com/pako@2.1.0/dist/pako.min.js"></script>
   <script>
     if (!WebAssembly.instantiateStreaming) {
       WebAssembly.instantiateStreaming = async (resp, importObject) => {
@@ -12,11 +13,18 @@
       };
     }
     const go = new Go();
-    WebAssembly.instantiateStreaming(fetch("oni-view.wasm"), go.importObject).then((result) => {
-      go.run(result.instance);
-    }).catch((err) => {
-      console.error(err);
-    });
+    fetch("oni-view.wasm.gz")
+      .then((resp) => resp.arrayBuffer())
+      .then((buf) => {
+        const decompressed = pako.ungzip(new Uint8Array(buf)).buffer;
+        return WebAssembly.instantiate(decompressed, go.importObject);
+      })
+      .then((result) => {
+        go.run(result.instance);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   </script>
 </head>
 <body>

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -5,7 +5,22 @@ env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o dist/oni-view-linux-amd64 
 #env CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o dist/oni-view-darwin-amd64 .
 #env CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o dist/oni-view-darwin-arm64 .
 env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -o dist/oni-view-windows-amd64.exe .
-env CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -o dist/oni-view.wasm .
+env CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o dist/oni-view.wasm .
+
+# Optimize the WebAssembly binary if wasm-opt is available.
+if command -v wasm-opt >/dev/null; then
+  wasm-opt -Oz \
+    --enable-reference-types \
+    --enable-bulk-memory \
+    --enable-mutable-globals \
+    --enable-sign-ext \
+    --enable-nontrapping-float-to-int \
+    dist/oni-view.wasm -o dist/oni-view.wasm
+fi
+
+# Compress the WASM to reduce size.
+gzip -9 -c dist/oni-view.wasm > dist/oni-view.wasm.gz
+rm dist/oni-view.wasm
 
 # Copy the JS runtime and HTML loader for WASM builds.
 cp $(go env GOROOT)/lib/wasm/wasm_exec.js dist/


### PR DESCRIPTION
## Summary
- gzip compress the WASM build and load with Pako
- optimize the WASM binary using wasm-opt when available
- document that index.html loads a compressed WASM file

## Testing
- `go test -tags test ./...`
- `bash scripts/build_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68674d6af668832aa3667140aca5e39a