### PR TITLE
Hide throbber after WASM loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
         return WebAssembly.instantiate(decompressed, go.importObject);
       })
       .then((result) => {
+        document.getElementById("loading").remove();
         go.run(result.instance);
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
- hide the loading throbber once the WASM is instantiated

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867522324d4832aafc4839dbba7466f