### PR TITLE
Disable item legend on mobile devices

### DIFF
--- a/main.go
+++ b/main.go
@@ -1068,6 +1068,7 @@ type Game struct {
 	loading        bool
 	status         string
 	iconResults    chan loadedIcon
+	mobile         bool
 }
 
 type label struct {
@@ -1300,7 +1301,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				float32(float64(g.astHeight)*2*g.zoom), clr, false)
 		}
 		labels := []label{}
-		useNumbers := g.zoom < LegendZoomThreshold
+		useNumbers := !g.mobile && g.zoom < LegendZoomThreshold
 		if g.legendMap == nil {
 			g.initObjectLegend()
 		}
@@ -1483,6 +1484,7 @@ func main() {
 		zoom:    1.0,
 		loading: true,
 		status:  "Fetching...",
+		mobile:  isMobile(),
 	}
 	go func() {
 		fmt.Println("Fetching:", *coord)

--- a/mobile_detect.go
+++ b/mobile_detect.go
@@ -1,0 +1,7 @@
+package main
+
+import "runtime"
+
+func isMobile() bool {
+	return runtime.GOOS == "android" || runtime.GOOS == "ios"
+}

--- a/mobile_detect_js.go
+++ b/mobile_detect_js.go
@@ -1,0 +1,20 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"strings"
+	"syscall/js"
+)
+
+func isMobile() bool {
+	nav := js.Global().Get("navigator")
+	if !nav.Truthy() {
+		return false
+	}
+	ua := strings.ToLower(nav.Get("userAgent").String())
+	if strings.Contains(ua, "android") || strings.Contains(ua, "iphone") || strings.Contains(ua, "ipad") {
+		return true
+	}
+	return strings.Contains(ua, "mobile")
+}


### PR DESCRIPTION
## Summary
- add a helper to detect mobile devices
- store a `mobile` flag on `Game`
- disable number legend on mobile devices

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68675923fba0832a8b1d67bd2d5412af