### PR TITLE
Enhance hover info overlay

### DIFF
--- a/types.go
+++ b/types.go
@@ -8,9 +8,15 @@ import (
 
 // Data structures used to decode the geyser information.
 type Geyser struct {
-	ID string `json:"id"`
-	X  int    `json:"x"`
-	Y  int    `json:"y"`
+	ID             string  `json:"id"`
+	X              int     `json:"x"`
+	Y              int     `json:"y"`
+	ActiveCycles   float64 `json:"activeCycles"`
+	AvgEmitRate    float64 `json:"avgEmitRate"`
+	DormancyCycles float64 `json:"dormancyCycles"`
+	EmitRate       float64 `json:"emitRate"`
+	EruptionTime   float64 `json:"eruptionTime"`
+	IdleTime       float64 `json:"idleTime"`
 }
 
 type PointOfInterest struct {


### PR DESCRIPTION
## Summary
- include geyser stats in JSON struct
- compute text dimensions for centering
- return detailed JSON on hover
- trigger redraw when hover info toggled
- render info overlay at bottom center

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867670c5444832aa3c722c3f28458e7