### PR TITLE
Enhance item info display

### DIFF
--- a/const.go
+++ b/const.go
@@ -28,6 +28,8 @@ const (
 	HelpIconSize        = 24
 	HelpMargin          = 10
 	CrosshairSize       = 10
+	InfoIconScale       = 0.3
+	InfoPanelAlpha      = 200
 	// WheelThrottle controls how often mouse wheel zoom is applied
 	// in WASM to account for faster scroll events.
 	WheelThrottle = 75 * time.Millisecond

--- a/display.go
+++ b/display.go
@@ -206,12 +206,14 @@ func formatNum(n float64) string {
 }
 
 func formatGeyserInfo(g Geyser) string {
-	return "Active Cycles: " + formatNum(g.ActiveCycles) +
-		"\nAvg Emit Rate: " + formatNum(g.AvgEmitRate) +
-		"\nDormancy Cycles: " + formatNum(g.DormancyCycles) +
-		"\nEmit Rate: " + formatNum(g.EmitRate) +
-		"\nEruption Time: " + formatNum(g.EruptionTime) +
-		"\nIdle Time: " + formatNum(g.IdleTime)
+	return fmt.Sprintf("X: %d\nY: %d\nActive Cycles: %s\nAvg Emit Rate: %s\nDormancy Cycles: %s\nEmit Rate: %s\nEruption Time: %s\nIdle Time: %s",
+		g.X, g.Y,
+		formatNum(g.ActiveCycles),
+		formatNum(g.AvgEmitRate),
+		formatNum(g.DormancyCycles),
+		formatNum(g.EmitRate),
+		formatNum(g.EruptionTime),
+		formatNum(g.IdleTime))
 }
 
 func formatPOIInfo(p PointOfInterest) string {


### PR DESCRIPTION
## Summary
- darken info panel background
- show item coordinates and icon in the info panel

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686778a06010832a84d2de9650643d3f