### PR TITLE
Improve mobile tap interaction

### DIFF
--- a/const.go
+++ b/const.go
@@ -30,6 +30,7 @@ const (
 	CrosshairSize       = 10
 	InfoIconScale       = 0.3
 	InfoPanelAlpha      = 200
+	TouchDragThreshold  = 10
 	// WheelThrottle controls how often mouse wheel zoom is applied
 	// in WASM to account for faster scroll events.
 	WheelThrottle = 75 * time.Millisecond


### PR DESCRIPTION
## Summary
- allow single-tap camera centering on mobile
- keep text backgrounds black when the item legend isn't displayed
- add constant for tap drag detection

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68677ace150c832ab20f12a5b8e5973a