### PR TITLE
Support WASM seed from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Run the build script to compile the program and copy the necessary runtime files
 ```
 
 Open `dist/index.html` in a browser to test the WebAssembly build. The page loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
+You can specify the seed coordinate in the URL using `?coord=<seed>` or in the
+fragment like `#coord=<seed>` and the viewer will load it automatically.
 
 ## Repository Layout
 

--- a/main.go
+++ b/main.go
@@ -1082,6 +1082,11 @@ func main() {
 	out := flag.String("out", "", "optional path to save JSON")
 	screenshot := flag.String("screenshot", "", "path to save a PNG screenshot and exit")
 	flag.Parse()
+	if runtime.GOARCH == "wasm" {
+		if c := coordFromURL(); c != "" {
+			*coord = c
+		}
+	}
 
 	game := &Game{
 		icons:   make(map[string]*ebiten.Image),

--- a/url_wasm.go
+++ b/url_wasm.go
@@ -1,0 +1,44 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"strings"
+	"syscall/js"
+)
+
+// coordFromURL retrieves the seed coordinate from the URL if present.
+// It supports query parameters like ?coord=SEED or ?seed=SEED and
+// also checks the hash fragment for the same patterns.
+func coordFromURL() string {
+	loc := js.Global().Get("location")
+	if !loc.Truthy() {
+		return ""
+	}
+	search := loc.Get("search").String()
+	if strings.HasPrefix(search, "?") {
+		search = search[1:]
+	}
+	for _, part := range strings.Split(search, "&") {
+		if strings.HasPrefix(part, "coord=") {
+			return strings.TrimPrefix(part, "coord=")
+		}
+		if strings.HasPrefix(part, "seed=") {
+			return strings.TrimPrefix(part, "seed=")
+		}
+	}
+	hash := loc.Get("hash").String()
+	if strings.HasPrefix(hash, "#") {
+		hash = hash[1:]
+	}
+	if strings.HasPrefix(hash, "coord=") {
+		return strings.TrimPrefix(hash, "coord=")
+	}
+	if strings.HasPrefix(hash, "seed=") {
+		return strings.TrimPrefix(hash, "seed=")
+	}
+	if hash != "" && !strings.Contains(hash, "=") {
+		return hash
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- look for a `coord` or `seed` in the page URL when running in WASM
- document how to load a seed via URL when using the web build

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68677c91acb4832aaf24dff37dc2eb19