### PR TITLE
Add screenshot export menu

### DIFF
--- a/const.go
+++ b/const.go
@@ -12,25 +12,27 @@ const (
 	PanSpeed         = 15
 	// CameraMargin controls how far the world can be panned
 	// beyond the visible screen in pixels.
-	CameraMargin        = -64
-	KeyZoomFactor       = 1.05
-	WheelZoomFactor     = 1.1
-	MinZoom             = 0.5
-	IconScale           = 0.2
-	LegendZoomExponent  = 10
-	DefaultWidth        = 1280
-	DefaultHeight       = 720
-	InitialZoom         = 1.0
-	LabelCharWidth      = 6
-	NumberLegendXOffset = 150
-	LegendRowSpacing    = 25
-	ScreenshotFile      = "screenshot.png"
-	HelpIconSize        = 24
-	HelpMargin          = 10
-	CrosshairSize       = 10
-	InfoIconScale       = 0.3
-	InfoPanelAlpha      = 200
-	TouchDragThreshold  = 10
+	CameraMargin          = -64
+	KeyZoomFactor         = 1.05
+	WheelZoomFactor       = 1.1
+	MinZoom               = 0.5
+	IconScale             = 0.2
+	LegendZoomExponent    = 10
+	DefaultWidth          = 1280
+	DefaultHeight         = 720
+	InitialZoom           = 1.0
+	LabelCharWidth        = 6
+	NumberLegendXOffset   = 150
+	LegendRowSpacing      = 25
+	ScreenshotFile        = "screenshot.png"
+	HelpIconSize          = 24
+	HelpMargin            = 10
+	CrosshairSize         = 10
+	InfoIconScale         = 0.3
+	InfoPanelAlpha        = 200
+	TouchDragThreshold    = 10
+	ScreenshotMenuSpacing = 18
+
 	// WheelThrottle controls how often mouse wheel zoom is applied
 	// in WASM to account for faster scroll events.
 	WheelThrottle = 75 * time.Millisecond

--- a/main.go
+++ b/main.go
@@ -469,6 +469,9 @@ type Game struct {
 	touchStartX    int
 	touchStartY    int
 	touchMoved     bool
+	showShotMenu   bool
+	ssAspect       int
+	ssQuality      int
 }
 
 type label struct {
@@ -776,6 +779,18 @@ iconsLoop:
 		} else if mousePressed && g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showHelp = true
 			g.needsRedraw = true
+		} else if g.showShotMenu {
+			if mousePressed {
+				if !g.clickScreenshotMenu(mx, my) {
+					if !g.screenshotMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+						g.showShotMenu = false
+						g.needsRedraw = true
+					}
+				}
+			}
+		} else if mousePressed && g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+			g.showShotMenu = true
+			g.needsRedraw = true
 		}
 	}
 
@@ -982,6 +997,16 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 
 		if !g.mobile {
+			// Draw screenshot icon
+			sr := g.screenshotRect()
+			scx := float32(sr.Min.X + HelpIconSize/2)
+			scy := float32(sr.Min.Y + HelpIconSize/2)
+			vector.DrawFilledCircle(screen, scx, scy, HelpIconSize/2, color.RGBA{0, 0, 0, 180}, true)
+			ebitenutil.DebugPrintAt(screen, "SS", sr.Min.X+3, sr.Min.Y+5)
+			if g.showShotMenu {
+				g.drawScreenshotMenu(screen)
+			}
+
 			// Draw help icon
 			hr := g.helpRect()
 			cx := float32(hr.Min.X + HelpIconSize/2)

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -1,0 +1,142 @@
+//go:build !test
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+func (g *Game) screenshotRect() image.Rectangle {
+	size := HelpIconSize
+	x := g.width - size*2 - HelpMargin*2
+	y := g.height - size - HelpMargin
+	return image.Rect(x, y, x+size, y+size)
+}
+
+func (g *Game) screenshotMenuRect() image.Rectangle {
+	labels := []string{"Square (1:1)", "Portrait (3:4)", "Low", "Medium", "High", "Extreme", "Save Screenshot"}
+	maxW := 0
+	for _, s := range labels {
+		if len(s) > maxW {
+			maxW = len(s)
+		}
+	}
+	w := maxW*LabelCharWidth + 4
+	h := len(labels)*ScreenshotMenuSpacing + 4
+	x := g.screenshotRect().Min.X - w - 10
+	if x < 0 {
+		x = 0
+	}
+	y := g.screenshotRect().Min.Y - h
+	if y < 0 {
+		y = 0
+	}
+	return image.Rect(x, y, x+w, y+h)
+}
+
+func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
+	rect := g.screenshotMenuRect()
+	vector.DrawFilledRect(dst, float32(rect.Min.X), float32(rect.Min.Y), float32(rect.Dx()), float32(rect.Dy()), colorRGBA(0, 0, 0, 200), false)
+	items := []string{"Square (1:1)", "Portrait (3:4)", "Low", "Medium", "High", "Extreme", "Save Screenshot"}
+	y := rect.Min.Y + 2
+	for i, it := range items {
+		selected := (i == g.ssAspect) || (i-2 == g.ssQuality && i >= 2 && i <= 5)
+		if selected {
+			drawTextWithBGBorder(dst, it, rect.Min.X+2, y, colorRGBA(255, 255, 255, 255))
+		} else {
+			drawTextWithBG(dst, it, rect.Min.X+2, y)
+		}
+		y += ScreenshotMenuSpacing
+	}
+}
+
+func (g *Game) clickScreenshotMenu(mx, my int) bool {
+	rect := g.screenshotMenuRect()
+	if !rect.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		return false
+	}
+	items := []string{"Square (1:1)", "Portrait (3:4)", "Low", "Medium", "High", "Extreme", "Save Screenshot"}
+	y := rect.Min.Y + 2
+	for i := range items {
+		r := image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+16+4)
+		if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+			switch i {
+			case 0:
+				g.ssAspect = 0
+			case 1:
+				g.ssAspect = 1
+			case 2, 3, 4, 5:
+				g.ssQuality = i - 2
+			case 6:
+				g.saveScreenshot()
+				g.showShotMenu = false
+			}
+			g.needsRedraw = true
+			return true
+		}
+		y += ScreenshotMenuSpacing
+	}
+	return false
+}
+
+func (g *Game) saveScreenshot() {
+	var height int
+	switch g.ssQuality {
+	case 0:
+		height = g.height
+	case 1:
+		height = 2048
+	case 2:
+		height = 4096
+	default:
+		height = 8192
+	}
+	width := height
+	if g.ssAspect == 1 {
+		width = height * 3 / 4
+	}
+	img := g.captureScreenshot(width, height)
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	name := fmt.Sprintf("%s-%s.png", g.coord, time.Now().Format("20060102-150405"))
+	_ = saveImageData(name, buf.Bytes())
+}
+
+func (g *Game) captureScreenshot(w, h int) *image.RGBA {
+	ow, oh := g.width, g.height
+	showHelp := g.showHelp
+	showInfo := g.showInfo
+	menu := g.showShotMenu
+	pinned := g.infoPinned
+	g.showHelp = false
+	g.showInfo = false
+	g.infoPinned = false
+	g.showShotMenu = false
+	g.Layout(w, h)
+	img := ebiten.NewImage(w, h)
+	g.needsRedraw = true
+	g.Draw(img)
+	b := img.Bounds()
+	pix := make([]byte, 4*b.Dx()*b.Dy())
+	img.ReadPixels(pix)
+	rgba := &image.RGBA{Pix: pix, Stride: 4 * b.Dx(), Rect: b}
+	g.Layout(ow, oh)
+	g.showHelp = showHelp
+	g.showInfo = showInfo
+	g.infoPinned = pinned
+	g.showShotMenu = menu
+	g.needsRedraw = true
+	return rgba
+}
+
+func colorRGBA(r, g0, b, a uint8) color.RGBA {
+	return color.RGBA{R: r, G: g0, B: b, A: a}
+}

--- a/screenshot_save.go
+++ b/screenshot_save.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package main
+
+import "os"
+
+func saveImageData(filename string, data []byte) error {
+	return os.WriteFile(filename, data, 0644)
+}

--- a/screenshot_save_wasm.go
+++ b/screenshot_save_wasm.go
@@ -1,0 +1,18 @@
+//go:build js && wasm
+
+package main
+
+import "syscall/js"
+
+func saveImageData(filename string, data []byte) error {
+	uint8Array := js.Global().Get("Uint8Array").New(len(data))
+	js.CopyBytesToJS(uint8Array, data)
+	blob := js.Global().Get("Blob").New([]any{uint8Array})
+	url := js.Global().Get("URL").Call("createObjectURL", blob)
+	a := js.Global().Get("document").Call("createElement", "a")
+	a.Set("href", url)
+	a.Set("download", filename)
+	a.Call("click")
+	js.Global().Get("URL").Call("revokeObjectURL", url)
+	return nil
+}


### PR DESCRIPTION
## Summary
- add screenshot menu constants
- implement screenshot save helpers for web/desktop
- add screenshot menu and screenshot icon rendering
- handle screenshot menu interactions

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686803210958832a8175b282bad80e35