### PR TITLE
Improve scaling and zoom limits

### DIFF
--- a/const.go
+++ b/const.go
@@ -15,7 +15,8 @@ const (
 	CameraMargin          = -64
 	KeyZoomFactor         = 1.05
 	WheelZoomFactor       = 1.1
-	MinZoom               = 0.5
+	MinZoom               = 0.25
+	MaxZoom               = 8.0
 	IconScale             = 0.2
 	LegendZoomExponent    = 10
 	DefaultWidth          = 800

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (g *Game) screenshotRect() image.Rectangle {
-	size := HelpIconSize
+	size := g.iconSize()
 	x := g.width - size*2 - HelpMargin*2
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)


### PR DESCRIPTION
## Summary
- allow zoom range from 25% to 800%
- adapt icon and text scaling for large windows and screenshots
- ensure screenshot and help buttons resize when needed
- center scaled labels correctly

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68682fb3e160832a922ce4f28c275210