### PR TITLE
Fix icon scaling

### DIFF
--- a/const.go
+++ b/const.go
@@ -12,12 +12,16 @@ const (
 	PanSpeed         = 15
 	// CameraMargin controls how far the world can be panned
 	// beyond the visible screen in pixels.
-	CameraMargin          = -64
-	KeyZoomFactor         = 1.05
-	WheelZoomFactor       = 1.1
-	MinZoom               = 0.25
-	MaxZoom               = 8.0
-	IconScale             = 0.2
+	CameraMargin    = -64
+	KeyZoomFactor   = 1.05
+	WheelZoomFactor = 1.1
+	MinZoom         = 0.25
+	MaxZoom         = 8.0
+	IconScale       = 0.2
+	// BaseIconPixels is the target pixel size used when scaling
+	// geyser and POI icons. Larger icons are scaled down so the
+	// on-screen size is consistent across all items.
+	BaseIconPixels        = 96
 	LegendZoomExponent    = 10
 	DefaultWidth          = 800
 	DefaultHeight         = 800

--- a/main.go
+++ b/main.go
@@ -568,8 +568,10 @@ func (g *Game) itemAt(mx, my int) (string, int, int, *ebiten.Image, bool) {
 		left, top, right, bottom := x-hitRadius, y-hitRadius, x+hitRadius, y+hitRadius
 		if iconName := iconForGeyser(gy.ID); iconName != "" {
 			if img, ok := g.icons[iconName]; ok && img != nil {
-				w := float64(img.Bounds().Dx()) * g.zoom * IconScale
-				h := float64(img.Bounds().Dy()) * g.zoom * IconScale
+				maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+				scale := g.zoom * IconScale * float64(BaseIconPixels) / maxDim
+				w := float64(img.Bounds().Dx()) * scale
+				h := float64(img.Bounds().Dy()) * scale
 				left = x - w/2
 				top = y - h/2
 				right = x + w/2
@@ -591,8 +593,10 @@ func (g *Game) itemAt(mx, my int) (string, int, int, *ebiten.Image, bool) {
 		left, top, right, bottom := x-hitRadius, y-hitRadius, x+hitRadius, y+hitRadius
 		if iconName := iconForPOI(poi.ID); iconName != "" {
 			if img, ok := g.icons[iconName]; ok && img != nil {
-				w := float64(img.Bounds().Dx()) * g.zoom * IconScale
-				h := float64(img.Bounds().Dy()) * g.zoom * IconScale
+				maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+				scale := g.zoom * IconScale * float64(BaseIconPixels) / maxDim
+				w := float64(img.Bounds().Dx()) * scale
+				h := float64(img.Bounds().Dy()) * scale
 				left = x - w/2
 				top = y - h/2
 				right = x + w/2
@@ -975,9 +979,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if iconName := iconForGeyser(gy.ID); iconName != "" {
 				if img, ok := g.icons[iconName]; ok && img != nil {
 					op := &ebiten.DrawImageOptions{Filter: ebiten.FilterLinear}
-					op.GeoM.Scale(g.zoom*IconScale, g.zoom*IconScale)
-					w := float64(img.Bounds().Dx()) * g.zoom * IconScale
-					h := float64(img.Bounds().Dy()) * g.zoom * IconScale
+					maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+					scale := g.zoom * IconScale * float64(BaseIconPixels) / maxDim
+					op.GeoM.Scale(scale, scale)
+					w := float64(img.Bounds().Dx()) * scale
+					h := float64(img.Bounds().Dy()) * scale
 					op.GeoM.Translate(x-w/2, y-h/2)
 					screen.DrawImage(img, op)
 					if useNumbers {
@@ -1017,9 +1023,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if iconName := iconForPOI(poi.ID); iconName != "" {
 				if img, ok := g.icons[iconName]; ok && img != nil {
 					op := &ebiten.DrawImageOptions{Filter: ebiten.FilterLinear}
-					op.GeoM.Scale(g.zoom*IconScale, g.zoom*IconScale)
-					w := float64(img.Bounds().Dx()) * g.zoom * IconScale
-					h := float64(img.Bounds().Dy()) * g.zoom * IconScale
+					maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+					scale := g.zoom * IconScale * float64(BaseIconPixels) / maxDim
+					op.GeoM.Scale(scale, scale)
+					w := float64(img.Bounds().Dx()) * scale
+					h := float64(img.Bounds().Dy()) * scale
 					op.GeoM.Translate(x-w/2, y-h/2)
 					screen.DrawImage(img, op)
 					if useNumbers {


### PR DESCRIPTION
## Summary
- add BaseIconPixels constant so item icons have a common drawn size
- scale geyser and POI icons based on the new constant

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68683394056c832aba69e4a8a799c703