### PR TITLE
Fix release assets packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,21 @@ jobs:
         with:
           go-version: 'stable'
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb webp
       - name: Download assets
         run: ./scripts/download_assets.sh
       - name: Run tests
         run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go test ./...
       - name: Build binaries
         run: ./scripts/build_all.sh
+      - name: Copy assets
+        run: |
+          cp -r assets dist/
+          cp -r icons dist/
       - uses: actions/upload-artifact@v4
         with:
           name: oni-view-builds
-          path: dist/*
+          path: dist
 
   release:
     needs: test-and-build
@@ -38,5 +42,6 @@ jobs:
           path: dist
       - uses: softprops/action-gh-release@v1
         with:
-          files: dist/*
+          files: |
+            dist/**
 


### PR DESCRIPTION
## Summary
- install webp so `dwebp` is available for asset conversion
- copy asset and icon folders into the build artifacts
- upload full `dist` directory when creating releases

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68686840441c832aa79d15c372df4147