### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
         with:
           go-version: 'stable'
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y xvfb webp
+        run: sudo apt-get update && sudo apt-get install -y webp
       - name: Download assets
         run: ./scripts/download_assets.sh
       - name: Run tests
-        run: xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' go test ./...
+        run: go test -tags test ./...
       - name: Build binaries
         run: ./scripts/build_all.sh
       - name: Copy assets


### PR DESCRIPTION
## Summary
- stop installing Xvfb in the release workflow
- run the unit tests directly without the screenshot step

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686869cbf920832a9156f2c631217185