### PR TITLE
Implement screenshot click delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ the environments are:
 
 Click the camera icon to open the screenshot menu. Choose a quality level
 (1×–8×) and the current view is written to a PNG named after the seed.
+After clicking **Save Screenshot** the button briefly shows *Taking Screenshot...*
+with a red outline before the menu closes automatically.
 You can also generate a screenshot non-interactively:
 
 ```bash


### PR DESCRIPTION
## Summary
- disable input while a screenshot is being taken
- display **Taking Screenshot...** with red border before capture
- automatically close the screenshot menu after saving
- document the behavior in README

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68686a9d7364832a836159aaf849c18e