### PR TITLE
Fix GitHub release job token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
     needs: test-and-build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -45,6 +47,7 @@ jobs:
           path: dist
       - uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GIT_ACTIONS }}
           files: |
             dist/**
 


### PR DESCRIPTION
## Summary
- set `contents: write` permission for the release job so the default `GITHUB_TOKEN` can publish releases
- use `GIT_ACTIONS` secret for the release token

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68686dc2b678832a9ae71a0b411b361f