### PR TITLE
Fix redraw when window restored

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 * A water-drop icon opens a scrollable list of all geysers
   present on the map.
 * Icons load asynchronously so the map is usable immediately.
+* The screen refreshes automatically when the window is restored
+  and once a second to prevent blank displays.
 
 ## Controls
 


### PR DESCRIPTION
## Summary
- refresh screen when restoring from minimize
- redraw every second so minimized windows render correctly
- document automatic refresh in README

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68687cefd3c4832a9abec3fe52ca6aed