### PR TITLE
Crop biome textures

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -166,7 +166,7 @@ func loadBiomeTextures() map[string]*ebiten.Image {
 		}
 		col := i % cols
 		row := i / cols
-		r := image.Rect(col*tw, row*th, (col+1)*tw, (row+1)*th)
+		r := image.Rect(col*tw+1, row*th+1, (col+1)*tw-1, (row+1)*th-1)
 		sub := atlas.SubImage(r).(*image.NRGBA)
 		textures[name] = ebiten.NewImageFromImage(sub)
 	}


### PR DESCRIPTION
## Summary
- avoid texture bleeding by cropping biome textures by 1 pixel

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686881d74e6c832a87160d084502a93f