### PR TITLE
Embed images and simplify workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            webp xorg-dev libgl1-mesa-dev mingw-w64
-      - name: Download assets
-        run: ./scripts/download_assets.sh
+            xorg-dev libgl1-mesa-dev mingw-w64
       - name: Run tests
         run: go test -tags test ./...
       - name: Build binaries
         run: ./scripts/build_all.sh
-      - name: Copy assets
-        run: |
-          cp -r assets dist/
-          cp -r icons dist/
       - uses: actions/upload-artifact@v4
         with:
           name: oni-view-builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This repository contains a small ebiten viewer written in Go.
   gofmt -w *.go
   go test -tags test ./...
   ```
-- The assets directory is normally empty. If you need the image assets
-  run `./scripts/download_assets.sh`.
+- Image assets are committed to the repo and embedded at build time, so no
+  download step is required.
 
 Additional tasks to keep the project healthy:
  - Keep `README.md` up to date when features or build steps change.

--- a/README.md
+++ b/README.md
@@ -45,17 +45,9 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
    sudo apt-get install xorg-dev libgl1-mesa-dev mingw-w64
    ```
 
-3. **Download the image assets** – Icons used by the viewer are stored in the [`oni-seed-browser`](https://github.com/MapsNotIncluded/oni-seed-browser) repository. Run the helper script to clone the repo and copy the assets:
-
-   ```bash
-   ./scripts/download_assets.sh
-   ```
-
-   The script converts `.webp` icons to `.png` using `dwebp` and only downloads
-   the images referenced by the code. After it completes the PNG files will be
-   placed in the `assets/` directory. Install the `webp` package if needed.
-
-4. **Build and run** – Execute the program with a seed coordinate. The window defaults to 1280×720 but can be resized.
+3. **Build and run** – Execute the program with a seed coordinate. All required
+   image assets are embedded so no additional downloads are needed. The window
+   defaults to 1280×720 but can be resized.
 
    ```bash
    go run . -coord SNDST-A-7-0-0-0
@@ -117,8 +109,8 @@ go run . -coord SNDST-A-7-0-0-0 -screenshot myshot.png
 ## Repository Layout
 
 ```
-assets/     # Image files used by the viewer (downloaded separately)
-scripts/    # Helper scripts for asset download and headless execution
+assets/     # Embedded image files used by the viewer
+scripts/    # Helper scripts for headless execution
 main.go     # Program entry point and rendering logic
 display.go  # Icon selection and drawing helpers
 parse.go    # Functions for decoding biome path strings

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# install_deps.sh
+# Installs tools needed to build the oni-view application.
+
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y git curl build-essential \
+    libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
+    libxcursor-dev libxi-dev libxrender-dev libxxf86vm-dev \
+    libgl1-mesa-dev xorg-dev
+
+# Install Go 1.24.3 if not already available.
+if ! go version 2>/dev/null | grep -q "go1.24.3"; then
+    curl -LO https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
+    sudo tar -C /usr/local -xzf go1.24.3.linux-amd64.tar.gz
+    rm go1.24.3.linux-amd64.tar.gz
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+    export PATH=$PATH:/usr/local/go/bin
+fi
+
+# Fetch Go module dependencies.
+go mod download
+
+echo "Dependencies installed. Run 'go build' to compile the app."
+


### PR DESCRIPTION
## Summary
- embed PNG assets directly so they aren't fetched at runtime
- remove the asset download and copy steps from the release workflow
- update README to reflect embedded assets
- update contributor guidance in AGENTS.md
- add `install_deps.sh` for setting up build tools

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686882ed2068832aa76f2b4e894b9144