### PR TITLE
Remove JPEG biome binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,20 @@ go run . -coord SNDST-A-7-0-0-0 -screenshot myshot.png
 
 ```
 assets/     # Embedded image files used by the viewer
-scripts/    # Helper scripts for headless execution
+scripts/    # Helper scripts for headless execution and asset conversion
 main.go     # Program entry point and rendering logic
 display.go  # Icon selection and drawing helpers
 parse.go    # Functions for decoding biome path strings
 colors.go   # Color definitions for different biomes
 const.go    # Miscellaneous constants and configuration
 names.json  # Mapping tables for translating internal IDs to display names
+scripts/convert_biomes.sh  # Convert PNG biome textures to JPEG
+```
+
+Run the conversion script before building to generate the JPEG biome textures:
+
+```bash
+./scripts/convert_biomes.sh
 ```
 
 Unit tests live alongside the code (`main_test.go`, `zoom_test.go`). Format the

--- a/assets.go
+++ b/assets.go
@@ -17,9 +17,9 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
-// embed all PNG assets so no runtime fetching is needed
+// embed all image assets so no runtime fetching is needed
 //
-//go:embed assets/*.png icons/*.png biomes/*.png
+//go:embed assets/*.png icons/*.png biomes/*.jpg
 var assetFS embed.FS
 
 func openAsset(name string) (io.ReadCloser, error) {
@@ -133,7 +133,7 @@ func loadImage(cache map[string]*ebiten.Image, name string) (*ebiten.Image, erro
 func loadBiomeTextures() map[string]*ebiten.Image {
 	textures := make(map[string]*ebiten.Image)
 	for _, name := range biomeOrder {
-		img, err := loadImageFile("../biomes/" + name + ".png")
+		img, err := loadImageFile("../biomes/" + name + ".jpg")
 		if err != nil {
 			fmt.Println("load biome", name, ":", err)
 			continue

--- a/scripts/convert_biomes.go
+++ b/scripts/convert_biomes.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"image/jpeg"
+	"image/png"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	files, err := filepath.Glob("biomes/*.png")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, f := range files {
+		in, err := os.Open(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		img, err := png.Decode(in)
+		in.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+		base := filepath.Base(f)
+		name := strings.TrimSuffix(base, ".png") + ".jpg"
+		outName := filepath.Join(filepath.Dir(f), name)
+		out, err := os.Create(outName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := jpeg.Encode(out, img, &jpeg.Options{Quality: 90}); err != nil {
+			out.Close()
+			log.Fatal(err)
+		}
+		out.Close()
+	}
+}

--- a/scripts/convert_biomes.sh
+++ b/scripts/convert_biomes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# Convert all PNG textures in biomes/ to JPEG format.
+# Requires Go to be installed.
+
+go run "$(dirname "$0")/convert_biomes.go"


### PR DESCRIPTION
## Summary
- restore PNG textures in `biomes/`
- delete embedded JPEG binaries, but keep conversion script and README instructions

## Testing
- `./scripts/convert_biomes.sh`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6868b17368d4832a8a6d1b9ce71c124d