### PR TITLE
Add scrolling to legend panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   useful for lining up precise screenshots.
 * A water-drop icon opens a scrollable list of all geysers
   present on the map.
+* Biome and item legend panels scroll when they extend past the window height.
 * Icons load asynchronously so the map is usable immediately.
 * The screen refreshes automatically when the window is restored
   and once a second to prevent blank displays.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   useful for lining up precise screenshots.
 * A water-drop icon opens a scrollable list of all geysers
   present on the map.
-* Biome and item legend panels scroll when they extend past the window height.
+* Biome and item legend panels scroll when they extend past the window height,
+  with extra space so items near the bottom can clear the icons.
 * Icons load asynchronously so the map is usable immediately.
 * The screen refreshes automatically when the window is restored
   and once a second to prevent blank displays.

--- a/const.go
+++ b/const.go
@@ -21,14 +21,17 @@ const (
 	// BaseIconPixels is the target pixel size used when scaling
 	// geyser and POI icons. Larger icons are scaled down so the
 	// on-screen size is consistent across all items.
-	BaseIconPixels        = 96
-	LegendZoomExponent    = 10
-	DefaultWidth          = 1200
-	DefaultHeight         = 1200
-	InitialZoom           = 1.0
-	LabelCharWidth        = 6
-	NumberLegendXOffset   = 150
-	LegendRowSpacing      = 25
+	BaseIconPixels      = 96
+	LegendZoomExponent  = 10
+	DefaultWidth        = 1200
+	DefaultHeight       = 1200
+	InitialZoom         = 1.0
+	LabelCharWidth      = 6
+	NumberLegendXOffset = 150
+	LegendRowSpacing    = 25
+	// LegendScrollExtraRows controls how many additional rows the legend
+	// panels can scroll beyond the bottom of the screen.
+	LegendScrollExtraRows = 3
 	ScreenshotFile        = "screenshot.png"
 	HelpIconSize          = 24
 	HelpMargin            = 10

--- a/main.go
+++ b/main.go
@@ -513,7 +513,8 @@ func (g *Game) maxBiomeScroll() float64 {
 	}
 	scale := g.uiScale()
 	h := float64(g.legend.Bounds().Dy()) * scale
-	max := h - float64(g.height)
+	extra := float64(LegendRowSpacing*LegendScrollExtraRows) * scale
+	max := h - float64(g.height) + extra
 	if max < 0 {
 		max = 0
 	}
@@ -526,7 +527,8 @@ func (g *Game) maxItemScroll() float64 {
 	}
 	scale := g.uiScale()
 	h := float64(g.legendImage.Bounds().Dy()) * scale
-	max := h + 10 - float64(g.height)
+	extra := float64(LegendRowSpacing*LegendScrollExtraRows) * scale
+	max := h + 10 - float64(g.height) + extra
 	if max < 0 {
 		max = 0
 	}
@@ -1684,6 +1686,17 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 			zx := float64(g.width) / (float64(g.astWidth) * 2)
 			zy := float64(g.height) / (float64(g.astHeight) * 2)
 			g.minZoom = math.Min(zx, zy) * 0.25
+		}
+
+		if max := g.maxBiomeScroll(); max == 0 {
+			g.biomeScroll = 0
+		} else if g.biomeScroll > max {
+			g.biomeScroll = max
+		}
+		if max := g.maxItemScroll(); max == 0 {
+			g.itemScroll = 0
+		} else if g.itemScroll > max {
+			g.itemScroll = max
 		}
 
 		g.needsRedraw = true

--- a/main.go
+++ b/main.go
@@ -1118,6 +1118,16 @@ iconsLoop:
 			g.needsRedraw = true
 		} else if justPressed && g.magnifyRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.magnify = !g.magnify
+			if max := g.maxBiomeScroll(); max == 0 {
+				g.biomeScroll = 0
+			} else if g.biomeScroll > max {
+				g.biomeScroll = max
+			}
+			if max := g.maxItemScroll(); max == 0 {
+				g.itemScroll = 0
+			} else if g.itemScroll > max {
+				g.itemScroll = max
+			}
 			g.needsRedraw = true
 		} else if justPressed && g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.camX = oldX


### PR DESCRIPTION
## Summary
- allow biome and item panels to be scrolled with the mouse wheel
- keep hover selection in sync with panel scroll
- document legend scrolling in the README

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868d738e7b0832abd7bdee39fe565bd