### PR TITLE
Improve seed entry page

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,14 @@ sudo apt-get install xvfb   # one-time setup
 
 ## WebAssembly Build
 
-Run the build script to compile the program and copy the necessary runtime files. The WebAssembly module is optimized and compressed, with the runtime JavaScript and `index.html` placed in `dist/`.
+Run the build script to compile the program and copy the necessary runtime files. The WebAssembly module is optimized and compressed, with the runtime JavaScript and HTML files placed in `dist/`.
 
 ```bash
 ./scripts/build_all.sh
 ```
 
-Open `dist/index.html` in a browser to test the WebAssembly build. The page loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
-You can specify the seed coordinate in the URL using `?coord=<seed>` or in the
-fragment like `#coord=<seed>` and the viewer will load it automatically.
+Open `dist/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
+You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`.
 
 ## Desktop vs Web and Mobile
 

--- a/index.html
+++ b/index.html
@@ -2,66 +2,108 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Oni View Web</title>
+  <title>Oni Seed Viewer</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <style>
-    #loading {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+    body {
+      margin: 0;
+      height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
-      flex-direction: column;
-      font-family: sans-serif;
+      background: #121212;
+      color: #eee;
+      font-family: Roboto, sans-serif;
     }
 
-    .spinner {
-      width: 48px;
-      height: 48px;
-      border: 6px solid #ccc;
-      border-top-color: #333;
-      border-radius: 50%;
-      animation: spin 1s linear infinite;
-      margin-bottom: 8px;
+    .card {
+      text-align: center;
+      background: #1e1e1e;
+      padding: 2em;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     }
 
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
-      }
+    label {
+      display: block;
+      margin-bottom: 0.5em;
+      font-size: 1.2em;
+    }
+
+    input[type="text"] {
+      width: 16em;
+      padding: 0.5em;
+      border: none;
+      border-radius: 4px;
+      background: #222;
+      color: #fff;
+    }
+
+    input[type="text"]:focus {
+      outline: 2px solid #2196f3;
+    }
+
+    button {
+      margin-top: 1em;
+      padding: 0.5em 1em;
+      border: none;
+      border-radius: 4px;
+      background: #2196f3;
+      color: #fff;
+      font-size: 1em;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25em;
+    }
+
+    button:hover {
+      background: #42a5f5;
+    }
+
+    button .material-icons {
+      font-size: 1.2em;
+    }
+
+    #message {
+      margin-top: 1em;
+      color: #f44336;
+      height: 1.2em;
     }
   </style>
-  <script src="wasm_exec.js"></script>
-  <script src="https://unpkg.com/pako@2.1.0/dist/pako.min.js"></script>
-  <script>
-    if (!WebAssembly.instantiateStreaming) {
-      WebAssembly.instantiateStreaming = async (resp, importObject) => {
-        const source = await (await resp).arrayBuffer();
-        return await WebAssembly.instantiate(source, importObject);
-      };
-    }
-    const go = new Go();
-    fetch("oni-view.wasm.gz")
-      .then((resp) => resp.arrayBuffer())
-      .then((buf) => {
-        const decompressed = pako.ungzip(new Uint8Array(buf)).buffer;
-        return WebAssembly.instantiate(decompressed, go.importObject);
-      })
-      .then((result) => {
-        document.getElementById("loading").remove();
-        go.run(result.instance);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-  </script>
 </head>
 <body>
-  <div id="loading">
-    <div class="spinner"></div>
-    <div>Loading...</div>
+  <div class="card">
+    <form id="seedForm">
+      <label for="seedInput">Enter Seed</label>
+      <input id="seedInput" type="text" required />
+      <button type="submit"><span class="material-icons">search</span>View</button>
+    </form>
+    <div id="message"></div>
   </div>
+  <script>
+  const baseURL = "https://ingest.mapsnotincluded.org/coordinate/";
+  document.getElementById('seedForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const seed = document.getElementById('seedInput').value.trim();
+    if (!seed) return;
+    document.getElementById('message').textContent = 'Checking…';
+    try {
+      const resp = await fetch(baseURL + encodeURIComponent(seed));
+      if (resp.ok) {
+        if (resp.body && typeof resp.body.cancel === 'function') {
+          resp.body.cancel();
+        }
+        window.location.href = 'view.html?coord=' + encodeURIComponent(seed);
+      } else if (resp.status === 404) {
+        document.getElementById('message').textContent = 'Seed not found';
+      } else {
+        document.getElementById('message').textContent = 'Error: ' + resp.status;
+      }
+    } catch (err) {
+      document.getElementById('message').textContent = 'Request failed';
+    }
+  });
+  </script>
 </body>
 </html>

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -25,3 +25,4 @@ rm dist/oni-view.wasm
 # Copy the JS runtime and HTML loader for WASM builds.
 cp -f $(go env GOROOT)/lib/wasm/wasm_exec.js dist/
 cp -f index.html dist/
+cp -f view.html dist/

--- a/view.html
+++ b/view.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Oni View Web</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      background: #121212;
+      color: #eee;
+      font-family: Roboto, sans-serif;
+    }
+
+    #loading {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+    }
+
+    .spinner {
+      width: 48px;
+      height: 48px;
+      border: 6px solid #444;
+      border-top-color: #2196f3;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin-bottom: 8px;
+    }
+
+    #loading div:last-child {
+      font-size: 1.1em;
+      color: #ccc;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+  <script src="wasm_exec.js"></script>
+  <script src="https://unpkg.com/pako@2.1.0/dist/pako.min.js"></script>
+  <script>
+    if (!WebAssembly.instantiateStreaming) {
+      WebAssembly.instantiateStreaming = async (resp, importObject) => {
+        const source = await (await resp).arrayBuffer();
+        return await WebAssembly.instantiate(source, importObject);
+      };
+    }
+    const go = new Go();
+    fetch("oni-view.wasm.gz")
+      .then((resp) => resp.arrayBuffer())
+      .then((buf) => {
+        const decompressed = pako.ungzip(new Uint8Array(buf)).buffer;
+        return WebAssembly.instantiate(decompressed, go.importObject);
+      })
+      .then((result) => {
+        document.getElementById("loading").remove();
+        go.run(result.instance);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  </script>
+</head>
+<body>
+  <div id="loading">
+    <div class="spinner"></div>
+    <div>Loading...</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- modern dark theme for seed entry
- material icon styling
- clarify README for the new look

## Testing
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6868e29ad078832aa131c502c64f4b30