### PR TITLE
Add coord forwarding for index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run the build script to compile the program and copy the necessary runtime files
 ```
 
 Open `dist/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
-You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`.
+You can also provide the seed in the index page URL with `index.html?coord=<seed>` or `index.html#coord=<seed>` (just `#<seed>` works too) and it will forward you to the viewer automatically. You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`.
 
 ## Desktop vs Web and Mobile
 

--- a/index.html
+++ b/index.html
@@ -102,6 +102,24 @@
   </div>
   <script>
   const baseURL = "https://ingest.mapsnotincluded.org/coordinate/";
+  function seedFromURL() {
+    const search = window.location.search.slice(1);
+    for (const part of search.split('&')) {
+      if (part.startsWith('coord=')) return decodeURIComponent(part.slice(6));
+      if (part.startsWith('seed=')) return decodeURIComponent(part.slice(5));
+    }
+    let hash = window.location.hash.slice(1);
+    if (hash.startsWith('coord=')) return decodeURIComponent(hash.slice(6));
+    if (hash.startsWith('seed=')) return decodeURIComponent(hash.slice(5));
+    if (hash && !hash.includes('=')) return decodeURIComponent(hash);
+    return '';
+  }
+
+  const urlSeed = seedFromURL();
+  if (urlSeed) {
+    window.location.href = 'view.html?coord=' + encodeURIComponent(urlSeed);
+  }
+
   document.getElementById('seedForm').addEventListener('submit', async (e) => {
     e.preventDefault();
     const seed = document.getElementById('seedInput').value.trim();


### PR DESCRIPTION
## Summary
- forward `coord` or `seed` values in `index.html` to `view.html`
- document the forwarding feature in `README`

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6868e6d72ad0832a8835a38128a201b2