### PR TITLE
Add asteroid URL parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run the build script to compile the program and copy the necessary runtime files
 ```
 
 Open `dist/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
-You can also provide the seed in the index page URL with `index.html?coord=<seed>` or `index.html#coord=<seed>` (just `#<seed>` works too) and it will forward you to the viewer automatically. You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`.
+You can also provide the seed in the index page URL with `index.html?coord=<seed>` or `index.html#coord=<seed>` (just `#<seed>` works too) and it will forward you to the viewer automatically. You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`. Add `asteroid=<num>` to select a different asteroid when a seed contains multiple.
 
 ## Desktop vs Web and Mobile
 
@@ -94,7 +94,8 @@ the environments are:
   Screenshot, help and geyser icons are always visible and you interact using
   the mouse and keyboard.
 * **WebAssembly** – No command line flags are available. The viewer reads the
-  seed from the page URL using `?coord=` or `#coord=` parameters.
+  seed from the page URL using `?coord=` or `#coord=` parameters and an optional
+  `asteroid=` number.
 * **Mobile** – When running on a mobile OS or in a mobile browser the toolbar
   icons are hidden. Item details appear when the crosshair is centered over a
   geyser or POI, or a POI is clicked, and you pan or zoom using touch gestures.

--- a/index.html
+++ b/index.html
@@ -115,9 +115,22 @@
     return '';
   }
 
+  function asteroidFromURL() {
+    const search = window.location.search.slice(1);
+    for (const part of search.split('&')) {
+      if (part.startsWith('asteroid=')) return decodeURIComponent(part.slice(9));
+    }
+    const hash = window.location.hash.slice(1);
+    if (hash.startsWith('asteroid=')) return decodeURIComponent(hash.slice(9));
+    return '';
+  }
+
   const urlSeed = seedFromURL();
+  const urlAsteroid = asteroidFromURL();
   if (urlSeed) {
-    window.location.href = 'view.html?coord=' + encodeURIComponent(urlSeed);
+    let dest = 'view.html?coord=' + encodeURIComponent(urlSeed);
+    if (urlAsteroid) dest += '&asteroid=' + encodeURIComponent(urlAsteroid);
+    window.location.href = dest;
   }
 
   document.getElementById('seedForm').addEventListener('submit', async (e) => {

--- a/main.go
+++ b/main.go
@@ -1719,9 +1719,13 @@ func main() {
 	out := flag.String("out", "", "optional path to save JSON")
 	screenshot := flag.String("screenshot", "", "path to save a PNG screenshot and exit")
 	flag.Parse()
+	asteroidIdx := 0
 	if runtime.GOARCH == "wasm" {
 		if c := coordFromURL(); c != "" {
 			*coord = c
+		}
+		if a := asteroidFromURL(); a >= 0 {
+			asteroidIdx = a
 		}
 	}
 
@@ -1740,7 +1744,7 @@ func main() {
 		hoverItem:  -1,
 		mousePrev:  false,
 	}
-	go func() {
+	go func(idx int) {
 		fmt.Println("Fetching:", *coord)
 		cborData, err := fetchSeedCBOR(*coord)
 		if err != nil {
@@ -1760,7 +1764,11 @@ func main() {
 			jsonData, _ := json.MarshalIndent(seed, "", "  ")
 			_ = saveToFile(*out, jsonData)
 		}
-		ast := seed.Asteroids[0]
+		astIdxSel := 0
+		if idx >= 0 && idx < len(seed.Asteroids) {
+			astIdxSel = idx
+		}
+		ast := seed.Asteroids[astIdxSel]
 		bps := parseBiomePaths(ast.BiomePaths)
 		game.geysers = ast.Geysers
 		game.pois = ast.POIs

--- a/url.go
+++ b/url.go
@@ -6,3 +6,8 @@ package main
 func coordFromURL() string {
 	return ""
 }
+
+// asteroidFromURL returns -1 on non-web builds.
+func asteroidFromURL() int {
+	return -1
+}

--- a/url_wasm.go
+++ b/url_wasm.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 	"syscall/js"
 )
@@ -37,4 +38,30 @@ func coordFromURL() string {
 		return hash
 	}
 	return ""
+}
+
+// asteroidFromURL retrieves the asteroid index from the URL if present.
+// It looks for an `asteroid=NUM` query parameter or hash fragment.
+func asteroidFromURL() int {
+	loc := js.Global().Get("location")
+	if !loc.Truthy() {
+		return -1
+	}
+	search := strings.TrimPrefix(loc.Get("search").String(), "?")
+	for _, part := range strings.Split(search, "&") {
+		if strings.HasPrefix(part, "asteroid=") {
+			num, err := strconv.Atoi(strings.TrimPrefix(part, "asteroid="))
+			if err == nil {
+				return num
+			}
+		}
+	}
+	hash := strings.TrimPrefix(loc.Get("hash").String(), "#")
+	if strings.HasPrefix(hash, "asteroid=") {
+		num, err := strconv.Atoi(strings.TrimPrefix(hash, "asteroid="))
+		if err == nil {
+			return num
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## Summary
- pick a specific asteroid with the new `asteroid` query parameter
- carry the optional parameter through the index page
- parse `asteroid` on wasm builds and pass the value into the game
- document the new option
- fix accidental parameter use in icon loader

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686959270468832a90b84735e5d0ad08