### PR TITLE
Add asteroid selection on the start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Run the build script to compile the program and copy the necessary runtime files
 ./scripts/build_all.sh
 ```
 
-Open `dist/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
+Open `dist/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons and now includes an optional field to choose the asteroid index. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
 You can also provide the seed in the index page URL with `index.html?coord=<seed>` or `index.html#coord=<seed>` (just `#<seed>` works too) and it will forward you to the viewer automatically. You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`. Add `asteroid=<num>` to select a different asteroid when a seed contains multiple. When an asteroid index is provided the viewer shows it next to the seed as `ast: <num>`. If the number is not valid the viewer simply displays "invalid asteroid ID" instead of loading the map.
 
 ## Desktop vs Web and Mobile

--- a/index.html
+++ b/index.html
@@ -96,6 +96,8 @@
     <form id="seedForm">
       <label for="seedInput">Enter Seed</label>
       <input id="seedInput" type="text" required />
+      <label for="astInput">Asteroid (optional)</label>
+      <input id="astInput" type="number" min="0" step="1" />
       <button type="submit"><span class="material-icons">search</span>View</button>
     </form>
     <div id="message"></div>
@@ -127,6 +129,9 @@
 
   const urlSeed = seedFromURL();
   const urlAsteroid = asteroidFromURL();
+  if (urlAsteroid) {
+    document.getElementById('astInput').value = urlAsteroid;
+  }
   if (urlSeed) {
     let dest = 'view.html?coord=' + encodeURIComponent(urlSeed);
     if (urlAsteroid) dest += '&asteroid=' + encodeURIComponent(urlAsteroid);
@@ -136,6 +141,7 @@
   document.getElementById('seedForm').addEventListener('submit', async (e) => {
     e.preventDefault();
     const seed = document.getElementById('seedInput').value.trim();
+    const ast = document.getElementById('astInput').value.trim();
     if (!seed) return;
     document.getElementById('message').textContent = 'Checking…';
     try {
@@ -144,7 +150,9 @@
         if (resp.body && typeof resp.body.cancel === 'function') {
           resp.body.cancel();
         }
-        window.location.href = 'view.html?coord=' + encodeURIComponent(seed);
+        let dest = 'view.html?coord=' + encodeURIComponent(seed);
+        if (ast) dest += '&asteroid=' + encodeURIComponent(ast);
+        window.location.href = dest;
       } else if (resp.status === 404) {
         document.getElementById('message').textContent = 'Seed not found';
       } else {


### PR DESCRIPTION
## Summary
- allow users to select asteroid index on `index.html`
- forward the selected asteroid to the viewer and pre-fill from URL
- document the new input field in `README.md`

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68696dfcda9c832ab4691ecace128c7b