### PR TITLE
Update mobile defaults and options menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   Clicking pins the panel so it stays visible while panning.
 * A help icon displays the available controls at any time.
 * A gear icon opens an options menu for toggling textures, Vsync,
-  touch controls, item labels, legends, number labels and smart rendering.
+  item labels, legends, number labels and smart rendering,
+  adjusting icon size and showing the current FPS.
 * A `+` icon toggles enlarged UI text for accessibility.
 * Crosshairs at the center show the current world coordinates,
   useful for lining up precise screenshots.

--- a/main.go
+++ b/main.go
@@ -740,7 +740,6 @@ type Game struct {
 
 	textures      bool
 	vsync         bool
-	touchControls bool
 	showItemNames bool
 	showLegend    bool
 	useNumbers    bool
@@ -2029,9 +2028,8 @@ func main() {
 		asteroidID:        asteroidIDVal,
 		asteroidSpecified: asteroidSpecified,
 		mobile:            isMobile(),
-		textures:          true,
+		textures:          !isMobile(),
 		vsync:             true,
-		touchControls:     isMobile(),
 		showItemNames:     true,
 		showLegend:        true,
 		useNumbers:        true,

--- a/options_menu.go
+++ b/options_menu.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 
@@ -22,14 +23,14 @@ func (g *Game) optionsMenuRect() image.Rectangle {
 		OptionsMenuTitle,
 		"Textures",
 		"Vsync",
-		"Touch Controls",
 		"Show Item Names",
 		"Show Legends",
 		"Use Item Numbers",
-		"Icon Size +",
-		"Icon Size -",
+		"Icon Size [-] [+]",
 		"Smart Rendering",
+		"FPS: 60.0",
 		"Version: " + ClientVersion,
+		"Close",
 	}
 	maxW := 0
 	for _, s := range labels {
@@ -55,29 +56,46 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	vector.DrawFilledRect(dst, float32(rect.Min.X), float32(rect.Min.Y), float32(rect.Dx()), float32(rect.Dy()), colorRGBA(0, 0, 0, 200), false)
 	drawTextWithBG(dst, OptionsMenuTitle, rect.Min.X+2, rect.Min.Y+2)
 	y := rect.Min.Y + 2 + OptionsMenuSpacing
-	items := []struct {
-		label   string
-		enabled bool
-	}{
-		{"Textures", g.textures},
-		{"Vsync", g.vsync},
-		{"Touch Controls", g.mobile},
-		{"Show Item Names", g.showItemNames},
-		{"Show Legends", g.showLegend},
-		{"Use Item Numbers", g.useNumbers},
-		{"Icon Size +", false},
-		{"Icon Size -", false},
-		{"Smart Rendering", g.smartRender},
-	}
-	for _, it := range items {
-		if it.enabled {
-			drawTextWithBGBorder(dst, it.label, rect.Min.X+2, y, color.RGBA{255, 255, 255, 255})
+
+	drawToggle := func(label string, enabled bool) {
+		if enabled {
+			drawTextWithBGBorder(dst, label, rect.Min.X+2, y, color.RGBA{255, 255, 255, 255})
 		} else {
-			drawTextWithBG(dst, it.label, rect.Min.X+2, y)
+			drawTextWithBG(dst, label, rect.Min.X+2, y)
 		}
 		y += OptionsMenuSpacing
 	}
+
+	drawToggle("Textures", g.textures)
+	drawToggle("Vsync", g.vsync)
+	drawToggle("Show Item Names", g.showItemNames)
+	drawToggle("Show Legends", g.showLegend)
+	drawToggle("Use Item Numbers", g.useNumbers)
+
+	label := "Icon Size"
+	drawTextWithBG(dst, label, rect.Min.X+2, y)
+	w, _ := textDimensions(label)
+	bx := rect.Min.X + 2 + w + 6
+	minus := image.Rect(bx, y-2, bx+16, y-2+20)
+	plus := image.Rect(bx+20, y-2, bx+36, y-2+20)
+	vector.DrawFilledRect(dst, float32(minus.Min.X), float32(minus.Min.Y), float32(minus.Dx()), float32(minus.Dy()), colorRGBA(0, 0, 0, 180), false)
+	vector.StrokeRect(dst, float32(minus.Min.X)+0.5, float32(minus.Min.Y)+0.5, float32(minus.Dx())-1, float32(minus.Dy())-1, 2, color.RGBA{255, 255, 255, 255}, false)
+	drawPlusMinus(dst, minus, true)
+	vector.DrawFilledRect(dst, float32(plus.Min.X), float32(plus.Min.Y), float32(plus.Dx()), float32(plus.Dy()), colorRGBA(0, 0, 0, 180), false)
+	vector.StrokeRect(dst, float32(plus.Min.X)+0.5, float32(plus.Min.Y)+0.5, float32(plus.Dx())-1, float32(plus.Dy())-1, 2, color.RGBA{255, 255, 255, 255}, false)
+	drawPlusMinus(dst, plus, false)
+	y += OptionsMenuSpacing
+
+	drawToggle("Smart Rendering", g.smartRender)
+
+	fps := fmt.Sprintf("FPS: %.1f", ebiten.ActualFPS())
+	drawTextWithBG(dst, fps, rect.Min.X+2, y)
+	y += OptionsMenuSpacing
+
 	drawTextWithBG(dst, "Version: "+ClientVersion, rect.Min.X+2, y)
+	y += OptionsMenuSpacing
+
+	drawTextWithBGBorder(dst, "Close", rect.Min.X+2, y, color.RGBA{255, 255, 255, 255})
 }
 
 func (g *Game) clickOptionsMenu(mx, my int) bool {
@@ -86,36 +104,94 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 		return false
 	}
 	y := rect.Min.Y + 2 + OptionsMenuSpacing
-	for i := 0; i < 9; i++ {
-		r := image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+16+4)
-		if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			switch i {
-			case 0:
-				g.textures = !g.textures
-			case 1:
-				g.vsync = !g.vsync
-				ebiten.SetVsyncEnabled(g.vsync)
-			case 2:
-				g.mobile = !g.mobile
-			case 3:
-				g.showItemNames = !g.showItemNames
-			case 4:
-				g.showLegend = !g.showLegend
-			case 5:
-				g.useNumbers = !g.useNumbers
-			case 6:
-				g.iconScale += 0.25
-			case 7:
-				if g.iconScale > 0.25 {
-					g.iconScale -= 0.25
-				}
-			case 8:
-				g.smartRender = !g.smartRender
-			}
-			g.needsRedraw = true
-			return true
-		}
-		y += OptionsMenuSpacing
+
+	// Textures
+	r := image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.textures = !g.textures
+		g.needsRedraw = true
+		return true
 	}
+	y += OptionsMenuSpacing
+
+	// Vsync
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.vsync = !g.vsync
+		ebiten.SetVsyncEnabled(g.vsync)
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Show Item Names
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.showItemNames = !g.showItemNames
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Show Legends
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.showLegend = !g.showLegend
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Use Item Numbers
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.useNumbers = !g.useNumbers
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Icon Size buttons
+	labelW, _ := textDimensions("Icon Size")
+	bx := rect.Min.X + 2 + labelW + 6
+	minus := image.Rect(bx, y-2, bx+16, y-2+20)
+	plus := image.Rect(bx+20, y-2, bx+36, y-2+20)
+	if minus.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		if g.iconScale > 0.25 {
+			g.iconScale -= 0.25
+		}
+		g.needsRedraw = true
+		return true
+	}
+	if plus.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.iconScale += 0.25
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Smart Rendering
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.smartRender = !g.smartRender
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// FPS (not clickable)
+	y += OptionsMenuSpacing
+
+	// Version (not clickable)
+	y += OptionsMenuSpacing
+
+	// Close
+	r = image.Rect(rect.Min.X, y-2, rect.Min.X+rect.Dx(), y-2+20)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.showOptions = false
+		g.needsRedraw = true
+		return true
+	}
+
 	return true
 }


### PR DESCRIPTION
## Summary
- disable textures by default on mobile
- show FPS and new icon size controls in the options menu
- remove obsolete touch control toggle and add a Close item
- update README to describe new menu behavior

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68698aa98508832a90c25e4437a0ed30