### PR TITLE
Update docs and add version bump script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ This repository contains a small ebiten viewer written in Go.
   ```
 - Image assets are committed to the repo and embedded at build time, so no
   download step is required.
+- Run `scripts/bump_version.sh` before committing to update `ClientVersion`
+  in `const.go`. The script writes `v0.0.0-YYMMDDHHMM` using the current UTC
+  time.
 
 Additional tasks to keep the project healthy:
  - Keep `README.md` up to date when features or build steps change.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ gofmt -w *.go
 go test -tags test ./...
 ```
 
+## Versioning
+
+Run `scripts/bump_version.sh` before committing. The script updates the
+`ClientVersion` constant in `const.go` to `v0.0.0-YYMMDDHHMM` using the
+current UTC time so builds display the correct version string.
+
 ## License
 
 The project is released under the MIT License. See [LICENSE](LICENSE) for full details.

--- a/const.go
+++ b/const.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.3"
+	ClientVersion    = "v0.0.0-2507052128"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="v0.0.0-$(date -u +%y%m%d%H%M)"
+# Replace the ClientVersion constant in const.go
+sed -i -E "s/ClientVersion\s*=\s*\"[^\"]+\"/ClientVersion    = \"$version\"/" const.go
+
+echo "Updated ClientVersion to $version"


### PR DESCRIPTION
## Summary
- document new versioning approach
- add instructions for bumping version before commits
- add helper script to update `ClientVersion`
- automatically set `ClientVersion` using short UTC datetime

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68699889f41c832a9cdf9f2bcd1b5713