### PR TITLE
Add half-res mode, tooltip fixes, and filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   selecting image quality from low (2K) to high (8K).
 * Hover over geyser or POI icons to show an information panel.
   Clicking pins the panel so it stays visible while panning.
-* Hover over the bottom icons for tooltips describing their actions.
+* Hover over the bottom icons for tooltips describing their actions. Tooltips
+  automatically stay within the window bounds.
 * A help icon displays the available controls at any time.
 * A gear icon opens an options menu for toggling textures, Vsync,
-  item labels, legends, number labels and smart rendering,
-  adjusting icon size and showing the current FPS.
+  item labels, legends, number labels, smart rendering, half-resolution
+  mode, automatic low-res switching and linear filtering. You can also
+  adjust icon size and view the current FPS.
 * A `+` icon toggles enlarged UI text for accessibility.
 * Crosshairs at the center show the current world coordinates,
   useful for lining up precise screenshots.

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.0-2507052207"
+	ClientVersion    = "v0.0.0-2507052220"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/options_menu.go
+++ b/options_menu.go
@@ -27,6 +27,9 @@ func (g *Game) optionsMenuRect() image.Rectangle {
 		"Use Item Numbers",
 		"Icon Size [-] [+]",
 		"Smart Rendering",
+		"Half Resolution",
+		"Auto Low-Res",
+		"Linear Filtering",
 		"FPS: 60.0",
 		"Version: " + ClientVersion,
 		"Close",
@@ -82,6 +85,9 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	y += OptionsMenuSpacing
 
 	drawToggle("Smart Rendering", g.smartRender)
+	drawToggle("Half Resolution", g.halfRes)
+	drawToggle("Auto Low-Res", g.autoLowRes)
+	drawToggle("Linear Filtering", g.linearFilter)
 
 	fps := fmt.Sprintf("FPS: %.1f", ebiten.ActualFPS())
 	ebitenutil.DebugPrintAt(dst, fps, rect.Min.X+6, y)
@@ -171,6 +177,33 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	r = image.Rect(rect.Min.X+4, y-4, rect.Max.X-4, y-4+22)
 	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		g.smartRender = !g.smartRender
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Half Resolution
+	r = image.Rect(rect.Min.X+4, y-4, rect.Max.X-4, y-4+22)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.halfRes = !g.halfRes
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Auto Low-Res
+	r = image.Rect(rect.Min.X+4, y-4, rect.Max.X-4, y-4+22)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.autoLowRes = !g.autoLowRes
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Linear Filtering
+	r = image.Rect(rect.Min.X+4, y-4, rect.Max.X-4, y-4+22)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.linearFilter = !g.linearFilter
 		g.needsRedraw = true
 		return true
 	}


### PR DESCRIPTION
## Summary
- keep tooltips inside the window
- add half-resolution rendering with automatic FPS-based toggle
- allow disabling the auto low-res switch and linear filtering
- document new options and bump version

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869a31933fc832a92669b38374b54ea