### PR TITLE
Update versioning instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ This repository contains a small ebiten viewer written in Go.
   ```
 - Image assets are committed to the repo and embedded at build time, so no
   download step is required.
-- Run `scripts/bump_version.sh` before committing to update `ClientVersion`
-  in `const.go`. The script writes `v0.0.0-YYMMDDHHMM` using the current UTC
-  time.
+- Run `scripts/bump_version.sh` before committing to update the timestamp in
+  the `ClientVersion` constant found in `const.go`. The script preserves the
+  existing `MAJOR.MINOR.PATCH` numbers. Increase these version numbers
+  manually when releasing new features or fixes and **never** decrease them.
 
 Additional tasks to keep the project healthy:
  - Keep `README.md` up to date when features or build steps change.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ go test -tags test ./...
 
 ## Versioning
 
-Run `scripts/bump_version.sh` before committing. The script updates the
-`ClientVersion` constant in `const.go` to `v0.0.0-YYMMDDHHMM` using the
-current UTC time so builds display the correct version string.
+Run `scripts/bump_version.sh` before committing. The script only updates the
+timestamp portion of the `ClientVersion` constant in `const.go` and leaves the
+`MAJOR.MINOR.PATCH` numbers unchanged. Update those numbers manually when
+appropriate and never decrease them so version history moves forward.
 
 ## License
 

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.0-2507052220"
+	ClientVersion    = "v0.0.0-2507052225"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15


### PR DESCRIPTION
## Summary
- clarify that `bump_version.sh` only updates the timestamp
- instruct contributors to increment semantic version numbers manually
- note the versioning rules in README
- update `ClientVersion` timestamp

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a5e4dd74832a876f7f74bb19a363