### PR TITLE
Fix half-res UI scaling

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.0-2507052225"
+	ClientVersion    = "v0.0.0-2507052234"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -892,10 +892,14 @@ func (g *Game) uiScale() float64 {
 		}
 		return 1.0
 	}
+	scale := 1.0
 	if g.magnify {
-		return 2.0
+		scale = 2.0
 	}
-	return 1.0
+	if g.halfRes {
+		scale /= 2.0
+	}
+	return scale
 }
 
 func (g *Game) iconSize() int {
@@ -2201,15 +2205,22 @@ func (g *Game) Draw(screen *ebiten.Image) {
 }
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	if g.width != outsideWidth || g.height != outsideHeight {
+	screenW := outsideWidth
+	screenH := outsideHeight
+	if g.halfRes && !g.screenshotMode {
+		screenW /= 2
+		screenH /= 2
+	}
+
+	if g.width != screenW || g.height != screenH {
 		// Keep the world position at the center of the screen fixed so
 		// resizing doesn't shift the view.
 		cxOld, cyOld := float64(g.width)/2, float64(g.height)/2
 		worldX := (cxOld - g.camX) / g.zoom
 		worldY := (cyOld - g.camY) / g.zoom
 
-		g.width = outsideWidth
-		g.height = outsideHeight
+		g.width = screenW
+		g.height = screenH
 
 		cxNew, cyNew := float64(g.width)/2, float64(g.height)/2
 		g.camX = cxNew - worldX*g.zoom
@@ -2234,10 +2245,7 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 		g.needsRedraw = true
 	}
-	if g.halfRes && !g.screenshotMode {
-		return outsideWidth / 2, outsideHeight / 2
-	}
-	return outsideWidth, outsideHeight
+	return screenW, screenH
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- adjust Layout to store actual screen dimensions
- reduce UI scale when using half-resolution rendering
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6869a7df3948832ab361e755852e9c0a