### PR TITLE
Advance version to v0.0.5

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.0-2507052234"
+	ClientVersion    = "v0.0.5-2507052242"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="v0.0.0-$(date -u +%y%m%d%H%M)"
+# Extract existing MAJOR.MINOR.PATCH from const.go
+current=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' const.go)
+version="${current}-$(date -u +%y%m%d%H%M)"
 # Replace the ClientVersion constant in const.go
 sed -i -E "s/ClientVersion\s*=\s*\"[^\"]+\"/ClientVersion    = \"$version\"/" const.go
 


### PR DESCRIPTION
## Summary
- bump patch version to v0.0.5 in `const.go`
- make `scripts/bump_version.sh` preserve existing MAJOR.MINOR.PATCH when bumping timestamp

## Testing
- `go test -tags test ./...` *(fails: undefined `whitePixel`)*

------
https://chatgpt.com/codex/tasks/task_e_6869a9a54e4c832ab707b02120375093