### PR TITLE
Improve screenshot menu and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 - **Mouse wheel or `+`/`-`** – zoom in and out.
 - **Drag with the mouse** – pan.
 - **Pinch gestures** – zoom on touch devices.
+- **Click or tap geysers/POIs** – view details in a popup.
+- **Hover legend entries** – highlight matching objects.
 - **Camera icon** – open the screenshot menu.
 - **Water-drop icon** – show a list of all geysers.
-- **Question mark** – display the help overlay.
-- **Plus icon** – enlarge the UI (turns to a minus when active).
+- **Question mark** – toggle the help overlay.
+- **Plus icon** – enlarge (or shrink) the UI.
+- **Gear icon** – open the options menu.
 
 ## Getting Started
 

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507052254"
+	ClientVersion    = "v0.0.5-2507052331"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15
@@ -48,6 +48,7 @@ const (
 	ScreenshotTakingLabel = "Taking Screenshot..."
 	ScreenshotSavedLabel  = "Saved!"
 	ScreenshotBWLabel     = "Black and White"
+	ScreenshotCloseLabel  = "Close"
 	GeyserRowSpacing      = 60
 	OptionsMenuSpacing    = 26
 	OptionsMenuTitle      = "Options:"


### PR DESCRIPTION
## Summary
- tweak screenshot icon position
- add Close option and temporary black & white toggle to screenshot menu
- enlarge screenshot help and README controls
- fix hidden item sprites when item names are off

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3f324e8832a8db4fef6a31aae6e