### PR TITLE
Fix bottom bar spacing

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507052331"
+	ClientVersion    = "v0.0.5-2507052355"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -982,7 +982,7 @@ func (g *Game) helpRect() image.Rectangle {
 
 func (g *Game) geyserRect() image.Rectangle {
 	size := g.iconSize()
-	x := g.width - size*5 - HelpMargin*5
+	x := g.width - size*4 - HelpMargin*4
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }

--- a/options_menu.go
+++ b/options_menu.go
@@ -12,7 +12,7 @@ import (
 
 func (g *Game) optionsRect() image.Rectangle {
 	size := g.iconSize()
-	x := g.width - size*6 - HelpMargin*6
+	x := g.width - size*5 - HelpMargin*5
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }


### PR DESCRIPTION
## Summary
- move the options and geyser buttons to fill the gap in the bottom toolbar
- bump client version

## Testing
- `go test -tags test ./...` *(fails: `X11/extensions/Xrandr.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6869baeb2c00832a9c47ff3743e95cba