### PR TITLE
Improve touch controls and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   item labels, legends, number labels, smart rendering, half-resolution
   mode, automatic low-res switching and linear filtering. You can also
   adjust icon size and view the current FPS.
-* A `+` icon toggles enlarged UI text for accessibility.
+* A **Magnify Text** option toggles enlarged UI text for accessibility.
 * Crosshairs at the center show the current world coordinates,
   useful for lining up precise screenshots.
 * A water-drop icon opens a scrollable list of all geysers
@@ -45,11 +45,11 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 - **Drag with the mouse** – pan.
 - **Pinch gestures** – zoom on touch devices.
 - **Click or tap geysers/POIs** – view details in a popup.
-- **Hover legend entries** – highlight matching objects.
+- **Hover or tap legend entries** – highlight and select matching objects.
 - **Camera icon** – open the screenshot menu.
 - **Water-drop icon** – show a list of all geysers.
 - **Question mark** – toggle the help overlay.
-- **Plus icon** – enlarge (or shrink) the UI.
+- **Magnify Text** option – enlarge or shrink the UI.
 - **Gear icon** – open the options menu.
 
 ## Getting Started

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507052355"
+	ClientVersion    = "v0.0.5-2507060015"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15
@@ -41,7 +41,7 @@ const (
 	InfoIconScale         = 0.3
 	InfoIconSize          = 32
 	InfoPanelAlpha        = 200
-	TouchDragThreshold    = 10
+	TouchDragThreshold    = 20
 	ScreenshotMenuSpacing = 26
 	ScreenshotMenuTitle   = "Image quality:"
 	ScreenshotSaveLabel   = "Save Screenshot"

--- a/main.go
+++ b/main.go
@@ -27,14 +27,14 @@ import (
 
 const helpMessage = "Controls:\n" +
 	"Arrow keys/WASD or drag – pan the map\n" +
-	"Mouse wheel or +/- – zoom in and out\n" +
+	"Mouse wheel or +/- keys – zoom in and out\n" +
 	"Pinch with two fingers – zoom on touch\n" +
 	"Click or tap geysers/POIs – show details\n" +
-	"Hover legend entries – highlight items\n" +
+	"Tap legend entries – select and highlight items\n" +
 	"Camera icon – open screenshot menu\n" +
 	"Water-drop icon – list all geysers\n" +
 	"Question mark – toggle this help\n" +
-	"Plus/Minus – enlarge or shrink UI\n" +
+	"Magnify Text option – enlarge the UI\n" +
 	"Gear icon – options"
 
 type hoverIcon int
@@ -45,7 +45,6 @@ const (
 	hoverGeysers
 	hoverScreenshot
 	hoverHelp
-	hoverMagnify
 )
 
 var errorBorderColor = color.RGBA{R: 244, G: 67, B: 54, A: 255}
@@ -735,8 +734,6 @@ func (g *Game) updateIconHover(mx, my int) {
 		g.hoverIcon = hoverScreenshot
 	case g.helpRect().Overlaps(pt):
 		g.hoverIcon = hoverHelp
-	case g.magnifyRect().Overlaps(pt):
-		g.hoverIcon = hoverMagnify
 	}
 	if prev != g.hoverIcon {
 		g.needsRedraw = true
@@ -966,23 +963,16 @@ func (g *Game) drawTooltip(dst *ebiten.Image, text string, rect image.Rectangle,
 	drawTextWithBGScale(dst, text, x, y, scale)
 }
 
-func (g *Game) magnifyRect() image.Rectangle {
+func (g *Game) helpRect() image.Rectangle {
 	size := g.iconSize()
 	x := g.width - size - HelpMargin
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }
 
-func (g *Game) helpRect() image.Rectangle {
-	size := g.iconSize()
-	x := g.width - size*2 - HelpMargin*2
-	y := g.height - size - HelpMargin
-	return image.Rect(x, y, x+size, y+size)
-}
-
 func (g *Game) geyserRect() image.Rectangle {
 	size := g.iconSize()
-	x := g.width - size*4 - HelpMargin*4
+	x := g.width - size*3 - HelpMargin*3
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }
@@ -999,7 +989,6 @@ func (g *Game) bottomTrayRect() image.Rectangle {
 	r = r.Union(g.geyserRect())
 	r = r.Union(g.screenshotRect())
 	r = r.Union(g.helpRect())
-	r = r.Union(g.magnifyRect())
 	return image.Rect(r.Min.X-4, r.Min.Y-4, r.Max.X+4, r.Max.Y+4)
 }
 
@@ -1264,7 +1253,7 @@ iconsLoop:
 		} else {
 			pt := image.Rect(x, y, x+1, y+1)
 			if g.helpRect().Overlaps(pt) || g.screenshotRect().Overlaps(pt) ||
-				g.magnifyRect().Overlaps(pt) || g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
+				g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 				g.touchUI = true
 			} else {
 				scale := g.uiScale()
@@ -1348,7 +1337,7 @@ iconsLoop:
 			} else {
 				pt := image.Rect(x, y, x+1, y+1)
 				if g.helpRect().Overlaps(pt) || g.screenshotRect().Overlaps(pt) ||
-					g.magnifyRect().Overlaps(pt) || g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
+					g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 					g.touchUI = true
 				} else {
 					scale := g.uiScale()
@@ -1434,19 +1423,6 @@ iconsLoop:
 			} else if g.optionsRect().Overlaps(pt) {
 				g.showOptions = true
 				g.needsRedraw = true
-			} else if g.magnifyRect().Overlaps(pt) {
-				g.magnify = !g.magnify
-				if max := g.maxBiomeScroll(); max == 0 {
-					g.biomeScroll = 0
-				} else if g.biomeScroll > max {
-					g.biomeScroll = max
-				}
-				if max := g.maxItemScroll(); max == 0 {
-					g.itemScroll = 0
-				} else if g.itemScroll > max {
-					g.itemScroll = max
-				}
-				g.needsRedraw = true
 			} else if g.helpRect().Overlaps(pt) {
 				g.showHelp = !g.showHelp
 				g.needsRedraw = true
@@ -1458,6 +1434,7 @@ iconsLoop:
 				g.needsRedraw = true
 			} else if g.touchUI {
 				g.updateHover(mx, my)
+				g.clickLegend(mx, my)
 			} else if g.mobile {
 				if _, ix, iy, _, found := g.itemAt(mx, my); found {
 					g.camX += float64(g.width/2 - ix)
@@ -1620,19 +1597,6 @@ iconsLoop:
 			g.needsRedraw = true
 		} else if justPressed && g.clickLegend(mx, my) {
 			// handled in clickLegend
-		} else if justPressed && g.magnifyRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.magnify = !g.magnify
-			if max := g.maxBiomeScroll(); max == 0 {
-				g.biomeScroll = 0
-			} else if g.biomeScroll > max {
-				g.biomeScroll = max
-			}
-			if max := g.maxItemScroll(); max == 0 {
-				g.itemScroll = 0
-			} else if g.itemScroll > max {
-				g.itemScroll = max
-			}
-			g.needsRedraw = true
 		} else if justPressed && g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.camX = oldX
 			g.camY = oldY
@@ -1988,13 +1952,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				g.drawScreenshotMenu(screen)
 			}
 
-			mr := g.magnifyRect()
-			mcx := float32(mr.Min.X + size/2)
-			mcy := float32(mr.Min.Y + size/2)
-			vector.DrawFilledCircle(screen, mcx, mcy, float32(size)/2, color.RGBA{0, 0, 0, 180}, true)
-			vector.StrokeCircle(screen, mcx, mcy, float32(size)/2, 1, buttonBorderColor, true)
-			drawPlusMinus(screen, mr, g.magnify)
-
 			hr := g.helpRect()
 			cx := float32(hr.Min.X + size/2)
 			cy := float32(hr.Min.Y + size/2)
@@ -2048,12 +2005,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				switch g.hoverIcon {
 				case hoverScreenshot:
 					g.drawTooltip(screen, "Screenshot", sr, scale)
-				case hoverMagnify:
-					lbl := "Enlarge UI"
-					if g.magnify {
-						lbl = "Shrink UI"
-					}
-					g.drawTooltip(screen, lbl, mr, scale)
 				case hoverHelp:
 					g.drawTooltip(screen, "Help", hr, scale)
 				case hoverOptions:

--- a/options_menu.go
+++ b/options_menu.go
@@ -12,7 +12,7 @@ import (
 
 func (g *Game) optionsRect() image.Rectangle {
 	size := g.iconSize()
-	x := g.width - size*5 - HelpMargin*5
+	x := g.width - size*4 - HelpMargin*4
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }
@@ -25,6 +25,7 @@ func (g *Game) optionsMenuSize() (int, int) {
 		"Show Item Names",
 		"Show Legends",
 		"Use Item Numbers",
+		"Magnify Text",
 		"Icon Size [-] [+]",
 		"Smart Rendering",
 		"Half Resolution",
@@ -82,6 +83,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Show Item Names", g.showItemNames)
 	drawToggle("Show Legends", g.showLegend)
 	drawToggle("Use Item Numbers", g.useNumbers)
+	drawToggle("Magnify Text", g.magnify)
 
 	label := "Icon Size"
 	ebitenutil.DebugPrintAt(img, label, 6, y)
@@ -171,6 +173,25 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	r = image.Rect(4, y-4, w-4, y-4+22)
 	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		g.useNumbers = !g.useNumbers
+		g.needsRedraw = true
+		return true
+	}
+	y += OptionsMenuSpacing
+
+	// Magnify Text
+	r = image.Rect(4, y-4, w-4, y-4+22)
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.magnify = !g.magnify
+		if max := g.maxBiomeScroll(); max == 0 {
+			g.biomeScroll = 0
+		} else if g.biomeScroll > max {
+			g.biomeScroll = max
+		}
+		if max := g.maxItemScroll(); max == 0 {
+			g.itemScroll = 0
+		} else if g.itemScroll > max {
+			g.itemScroll = max
+		}
 		g.needsRedraw = true
 		return true
 	}

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -16,7 +16,7 @@ import (
 
 func (g *Game) screenshotRect() image.Rectangle {
 	size := g.iconSize()
-	x := g.width - size*3 - HelpMargin*3
+	x := g.width - size*2 - HelpMargin*2
 	y := g.height - size - HelpMargin
 	return image.Rect(x, y, x+size, y+size)
 }


### PR DESCRIPTION
## Summary
- adjust touch detection threshold
- make legend entries respond to taps
- remove zoom icon and shift others
- add `Magnify Text` option to the menu
- enhance help overlay text

## Testing
- `go test -tags test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_6869beb29fe4832ab32715fc2600a5fb