### PR TITLE
Update loading screen progress

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507060055"
+	ClientVersion    = "v0.0.5-2507060107"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/view.html
+++ b/view.html
@@ -83,12 +83,15 @@
             chunks.push(value);
             received += value.length;
             if (total) {
-              document.getElementById("progress").value = (received / total) * 100;
+              const percent = (received / total) * 100;
+              document.getElementById("progress").value = percent;
+              document.getElementById("speed").textContent = percent.toFixed(0) + "%";
             }
-            const elapsed = (performance.now() - start) / 1000;
-            document.getElementById("speed").textContent =
-              (received / 1024 / (elapsed || 1)).toFixed(1) + " kB/s";
           }
+          if (total) {
+            document.getElementById("progress").value = 100;
+          }
+          document.getElementById("speed").textContent = "Loading application.";
           buf = new Uint8Array(received);
           let pos = 0;
           for (const chunk of chunks) {
@@ -98,6 +101,10 @@
           buf = buf.buffer;
         } else {
           buf = await resp.arrayBuffer();
+          if (total) {
+            document.getElementById("progress").value = 100;
+          }
+          document.getElementById("speed").textContent = "Loading application.";
         }
         const decompressed = pako.ungzip(new Uint8Array(buf)).buffer;
         return WebAssembly.instantiate(decompressed, go.importObject);


### PR DESCRIPTION
## Summary
- show percent loaded in view.html instead of speed in kB/s
- display "Loading application." once the download is finished
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cbd512b8832a9eae532c4eebc389