### PR TITLE
Fix help menu touch toggle

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507060107"
+	ClientVersion    = "v0.0.5-2507060120"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -1475,7 +1475,10 @@ iconsLoop:
 			} else if g.optionsRect().Overlaps(pt) {
 				g.showOptions = true
 				g.needsRedraw = true
-			} else if g.showHelp && !g.helpRect().Overlaps(pt) {
+			} else if g.helpRect().Overlaps(pt) {
+				g.showHelp = !g.showHelp
+				g.needsRedraw = true
+			} else if g.showHelp {
 				g.showHelp = false
 				g.needsRedraw = true
 			} else if g.geyserRect().Overlaps(pt) {


### PR DESCRIPTION
## Summary
- toggle help menu on touch release so touch events aren't missed
- bump version

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6869cd64e520832a807d6deb929f4a78