### PR TITLE
Fix item info layering and selection

### DIFF
--- a/main.go
+++ b/main.go
@@ -677,6 +677,10 @@ func (g *Game) maxItemScroll() float64 {
 	return max
 }
 
+func (g *Game) itemPanelVisible() bool {
+	return g.showLegend && g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+}
+
 func (g *Game) updateHover(mx, my int) {
 	prevBiome := g.hoverBiome
 	prevItem := g.hoverItem
@@ -1246,6 +1250,7 @@ iconsLoop:
 	if mxTmp < 0 || mxTmp >= g.width || myTmp < 0 || myTmp >= g.height {
 		mousePressed = false
 		mouseJustPressed = false
+		g.dragging = false
 	}
 	if g.ssPending > 0 || g.skipClickTicks > 0 {
 		mousePressed = false
@@ -1700,6 +1705,11 @@ iconsLoop:
 	}
 
 	if g.showInfo != prevShow || g.infoPinned != prevPinned || g.infoText != prevText || g.infoIcon != prevIcon {
+		g.needsRedraw = true
+	}
+
+	if !g.itemPanelVisible() && g.selectedItem != -1 {
+		g.selectedItem = -1
 		g.needsRedraw = true
 	}
 
@@ -2186,18 +2196,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			drawTextWithBGScale(screen, coords, 5, g.height-int(20*scale), scale)
 		}
 
-		if g.showShotMenu {
-			g.drawScreenshotMenu(screen)
-		}
-		if g.showOptions {
-			g.drawOptionsMenu(screen)
-		}
-		if g.showHelp && !g.screenshotMode {
-			scale := g.uiScale()
-			rect := g.helpMenuRect()
-			drawTextWithBGScale(screen, helpMessage, rect.Min.X, rect.Min.Y, scale)
-		}
-
 		if g.showInfo {
 			scale := g.uiScale()
 			w, h := textDimensions(g.infoText)
@@ -2214,6 +2212,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			tx := g.width/2 - int(float64(panelW)*scale)/2
 			ty := g.height - int(float64(panelH)*scale) - 30
 			g.drawInfoPanel(screen, g.infoText, g.infoIcon, tx, ty, scale)
+		}
+
+		if g.showShotMenu {
+			g.drawScreenshotMenu(screen)
+		}
+		if g.showOptions {
+			g.drawOptionsMenu(screen)
+		}
+		if g.showHelp && !g.screenshotMode {
+			scale := g.uiScale()
+			rect := g.helpMenuRect()
+			drawTextWithBGScale(screen, helpMessage, rect.Min.X, rect.Min.Y, scale)
 		}
 
 		g.needsRedraw = false


### PR DESCRIPTION
## Summary
- prevent selection from persisting when item panel hidden
- stop dragging when pointer leaves the window
- draw item info before any menus so menus overlay it

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869ce0d0fd8832a95c0890a8bb4386d