### PR TITLE
Fix screenshot menu width

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507060120"
+	ClientVersion    = "v0.0.5-2507060127"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -24,14 +24,17 @@ func (g *Game) screenshotRect() image.Rectangle {
 func (g *Game) screenshotMenuSize() (int, int) {
 	labels := append([]string{ScreenshotMenuTitle}, ScreenshotQualities...)
 	labels = append(labels, ScreenshotBWLabel, ScreenshotSaveLabel, ScreenshotCloseLabel)
+	itemCount := len(labels)
+	allLabels := append([]string(nil), labels...)
+	allLabels = append(allLabels, ScreenshotTakingLabel, ScreenshotSavedLabel)
 	maxW := 0
-	for _, s := range labels {
+	for _, s := range allLabels {
 		if len(s) > maxW {
 			maxW = len(s)
 		}
 	}
 	w := maxW*LabelCharWidth + 4
-	h := (len(labels)+1)*ScreenshotMenuSpacing + 4
+	h := (itemCount+1)*ScreenshotMenuSpacing + 4
 	return w, h
 }
 


### PR DESCRIPTION
## Summary
- handle dynamic button labels when calculating screenshot menu width
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: X11/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869d0b78de0832a806563ea6c8e4207