### PR TITLE
Enhance asteroid menu UI

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -27,6 +27,8 @@ func (g *Game) asteroidArrowRect() image.Rectangle {
 }
 
 func drawDownArrow(dst *ebiten.Image, rect image.Rectangle, up bool) {
+	drawFrame(dst, rect)
+
 	cx := float32(rect.Min.X + rect.Dx()/2)
 	cy := float32(rect.Min.Y + rect.Dy()/2)
 	half := float32(rect.Dx()) / 2

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507060127"
+	ClientVersion    = "v0.0.5-2507060137"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -1772,13 +1772,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		g.lastDraw = time.Now()
 		return
 	}
-	if g.showAstMenu {
-		screen.Fill(color.Black)
-		g.drawAsteroidMenu(screen)
-		g.needsRedraw = false
-		g.lastDraw = time.Now()
-		return
-	}
 	if g.loading || (len(g.biomes) == 0 && g.status != "") {
 		screen.Fill(color.RGBA{30, 30, 30, 255})
 		msg := g.status
@@ -2266,6 +2259,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 		if g.showOptions {
 			g.drawOptionsMenu(screen)
+		}
+		if g.showAstMenu {
+			g.drawAsteroidMenu(screen)
 		}
 		if g.showHelp && !g.screenshotMode {
 			scale := g.uiScale()


### PR DESCRIPTION
## Summary
- add a frame around the asteroid arrow to make it appear as a button
- overlay the asteroid menu without clearing the screen
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869d2b66070832a8cd7677c86100c52