### PR TITLE
Fix touch help and asteroid menu

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.5-2507060127"
+	ClientVersion    = "v0.0.5-2507060138"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -1337,11 +1337,7 @@ iconsLoop:
 			g.touchUI = true
 		} else {
 			pt := image.Rect(x, y, x+1, y+1)
-			if g.helpRect().Overlaps(pt) {
-				g.showHelp = !g.showHelp
-				g.needsRedraw = true
-				g.touchUI = true
-			} else if g.screenshotRect().Overlaps(pt) ||
+			if g.helpRect().Overlaps(pt) ||
 				g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 				g.touchUI = true
 			} else {
@@ -1511,6 +1507,9 @@ iconsLoop:
 				g.needsRedraw = true
 			} else if g.optionsRect().Overlaps(pt) {
 				g.showOptions = true
+				g.needsRedraw = true
+			} else if g.asteroidArrowRect().Overlaps(pt) {
+				g.showAstMenu = true
 				g.needsRedraw = true
 			} else if g.helpRect().Overlaps(pt) {
 				g.showHelp = !g.showHelp


### PR DESCRIPTION
## Summary
- fix help toggle double-fire on touch
- allow showing asteroid menu on touch
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6869d3152f90832a8755f4b61d2665cb