### PR TITLE
Add help overlay close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   Clicking pins the panel so it stays visible while panning.
 * Hover over the bottom icons for tooltips describing their actions. Tooltips
   automatically stay within the window bounds.
-* A help icon displays the available controls at any time.
+* A help icon displays the available controls at any time. An X button closes the overlay.
 * A gear icon opens an options menu for toggling textures, Vsync,
   item labels, legends, number labels, smart rendering, half-resolution
   mode, automatic low-res switching and linear filtering. You can also
@@ -50,6 +50,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 - **Camera icon** – open the screenshot menu.
 - **Geyser icon** – show a list of all geysers.
 - **Question mark** – toggle the help overlay.
+- **X button** – close the help overlay.
 - **Magnify Text** option – enlarge or shrink the UI.
 - **Gear icon** – open the options menu.
 

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060141"
+	ClientVersion    = "v0.0.6-2507060155"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func init() {
 		{"Camera icon", "open screenshot menu"},
 		{"Geyser-icon", "list all geysers"},
 		{"Question mark", "toggle this help"},
+		{"X button", "close this help"},
 		{"Gear icon", "open options"},
 	}
 	width := 0
@@ -1022,6 +1023,12 @@ func (g *Game) helpMenuRect() image.Rectangle {
 	return image.Rect(x, y, x+w, y+h)
 }
 
+func (g *Game) helpCloseRect() image.Rectangle {
+	size := g.iconSize()
+	r := g.helpMenuRect()
+	return image.Rect(r.Max.X-size-2, r.Min.Y+2, r.Max.X-2, r.Min.Y+size+2)
+}
+
 func (g *Game) geyserRect() image.Rectangle {
 	size := g.iconSize()
 	x := g.width - size*3 - HelpMargin*3
@@ -1514,7 +1521,7 @@ iconsLoop:
 			} else if g.helpRect().Overlaps(pt) {
 				g.showHelp = !g.showHelp
 				g.needsRedraw = true
-			} else if g.showHelp {
+			} else if g.showHelp && g.helpCloseRect().Overlaps(pt) {
 				g.showHelp = false
 				g.needsRedraw = true
 			} else if g.geyserRect().Overlaps(pt) {
@@ -1654,13 +1661,11 @@ iconsLoop:
 			g.touchUsed = false
 		}
 		g.lastMouseX, g.lastMouseY = mx, my
-		if g.showHelp {
-			if !g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-				g.showHelp = false
-				g.needsRedraw = true
-			}
-		} else if justPressed && g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.showHelp = true
+		if justPressed && g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+			g.showHelp = !g.showHelp
+			g.needsRedraw = true
+		} else if g.showHelp && justPressed && g.helpCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+			g.showHelp = false
 			g.needsRedraw = true
 		} else if g.showShotMenu {
 			if justPressed {
@@ -2266,6 +2271,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			scale := g.uiScale()
 			rect := g.helpMenuRect()
 			drawTextWithBGScale(screen, helpMessage, rect.Min.X, rect.Min.Y, scale)
+			cr := g.helpCloseRect()
+			drawCloseButton(screen, cr)
 		}
 
 		g.needsRedraw = false


### PR DESCRIPTION
## Summary
- add `helpCloseRect` and draw close button over help overlay
- remove automatic close on pointer exit
- toggle help overlay with question mark or close with 'X'
- document the new close button
- bump version

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6a7c92c832a8f12aab972434cd5