### PR TITLE
Improve auto low-quality mode FPS check

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060141"
+	ClientVersion    = "v0.0.6-2507060158"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15


### PR DESCRIPTION
## Summary
- handle auto low-quality FPS checks with a frame-based ticker
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: `X11/extensions/Xrandr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869d7a5ae30832aa48489fa57c9eb72