### PR TITLE
Auto center when switching asteroid

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -181,13 +181,7 @@ func (g *Game) loadAsteroid(ast Asteroid) {
 	g.astWidth = ast.SizeX
 	g.astHeight = ast.SizeY
 	g.legend, g.legendBiomes = buildLegendImage(bps)
-	zoomX := float64(g.width) / (float64(g.astWidth) * 2)
-	zoomY := float64(g.height) / (float64(g.astHeight) * 2)
-	g.zoom = math.Min(zoomX, zoomY)
-	g.minZoom = g.zoom * 0.25
-	g.camX = (float64(g.width) - float64(g.astWidth)*2*g.zoom) / 2
-	g.camY = (float64(g.height) - float64(g.astHeight)*2*g.zoom) / 2
-	g.clampCamera()
+	g.centerAndFit()
 	g.biomeTextures = loadBiomeTextures()
 	names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
 	set := make(map[string]struct{})
@@ -208,6 +202,19 @@ func (g *Game) loadAsteroid(ast Asteroid) {
 		}
 	}
 	g.startIconLoader(names)
+}
+
+func (g *Game) centerAndFit() {
+	if g.astWidth == 0 || g.astHeight == 0 {
+		return
+	}
+	zoomX := float64(g.width) / (float64(g.astWidth) * 2)
+	zoomY := float64(g.height) / (float64(g.astHeight) * 2)
+	g.zoom = math.Min(zoomX, zoomY)
+	g.minZoom = g.zoom * 0.25
+	g.camX = (float64(g.width) - float64(g.astWidth)*2*g.zoom) / 2
+	g.camY = (float64(g.height) - float64(g.astHeight)*2*g.zoom) / 2
+	g.clampCamera()
 }
 
 var colorWhite = color.RGBA{255, 255, 255, 255}

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060141"
+	ClientVersion    = "v0.0.6-2507060159"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -2445,13 +2445,7 @@ func main() {
 		game.astWidth = ast.SizeX
 		game.astHeight = ast.SizeY
 		game.legend, game.legendBiomes = buildLegendImage(bps)
-		zoomX := float64(game.width) / (float64(game.astWidth) * 2)
-		zoomY := float64(game.height) / (float64(game.astHeight) * 2)
-		game.zoom = math.Min(zoomX, zoomY)
-		game.minZoom = game.zoom * 0.25
-		game.camX = (float64(game.width) - float64(game.astWidth)*2*game.zoom) / 2
-		game.camY = (float64(game.height) - float64(game.astHeight)*2*game.zoom) / 2
-		game.clampCamera()
+		game.centerAndFit()
 		game.biomeTextures = loadBiomeTextures()
 		names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
 		set := make(map[string]struct{})


### PR DESCRIPTION
## Summary
- recenter and fit the camera whenever a new asteroid is loaded
- bump client version

## Testing
- `go test -tags test ./...` *(fails: GLFW requires X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_6869d7449d80832a88159fdbc9c927ce