### PR TITLE
Expand asteroid menu button area

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -25,6 +25,32 @@ func (g *Game) asteroidArrowRect() image.Rectangle {
 	return image.Rect(x, y, x+size, y+size)
 }
 
+// asteroidInfoRect returns the bounding rectangle surrounding the seed
+// coordinate, asteroid name, and arrow. This is used as the clickable area for
+// opening the asteroid menu.
+func (g *Game) asteroidInfoRect() image.Rectangle {
+	if g.coord == "" {
+		return image.Rectangle{}
+	}
+	scale := g.uiScale()
+	sw, sh := textDimensions(g.coord)
+	sx := g.width/2 - int(float64(sw)*scale/2)
+	seedRect := image.Rect(sx-2, 10-2, sx-2+int(float64(sw+4)*scale), 10-2+int(float64(sh+4)*scale))
+
+	name := g.asteroidID
+	if name == "" {
+		name = "Unknown"
+	}
+	astText := "Asteroid: " + name
+	aw, ah := textDimensions(astText)
+	ax := g.width/2 - int(float64(aw)*scale/2)
+	astRect := image.Rect(ax-2, int(30*scale)-2, ax-2+int(float64(aw+4)*scale), int(30*scale)-2+int(float64(ah+4)*scale))
+
+	rect := seedRect.Union(astRect)
+	rect = rect.Union(g.asteroidArrowRect())
+	return image.Rect(rect.Min.X-2, rect.Min.Y-2, rect.Max.X+2, rect.Max.Y+2)
+}
+
 func drawDownArrow(dst *ebiten.Image, rect image.Rectangle, up bool) {
 	drawFrame(dst, rect)
 

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060337"
+	ClientVersion    = "v0.0.6-2507060442"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -1165,7 +1165,7 @@ iconsLoop:
 		if mx >= 0 && mx < g.width && my >= 0 && my < g.height {
 			if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 				if !g.clickAsteroidMenu(mx, my) {
-					if !g.asteroidMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.asteroidArrowRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+					if !g.asteroidMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 						g.showAstMenu = false
 						g.needsRedraw = true
 					}
@@ -1176,7 +1176,7 @@ iconsLoop:
 			x, y := ebiten.TouchPosition(id)
 			if x >= 0 && x < g.width && y >= 0 && y < g.height {
 				if !g.clickAsteroidMenu(x, y) {
-					if !g.asteroidMenuRect().Overlaps(image.Rect(x, y, x+1, y+1)) && !g.asteroidArrowRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
+					if !g.asteroidMenuRect().Overlaps(image.Rect(x, y, x+1, y+1)) && !g.asteroidInfoRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
 						g.showAstMenu = false
 						g.needsRedraw = true
 					}
@@ -1417,7 +1417,7 @@ iconsLoop:
 			} else if g.optionsRect().Overlaps(pt) {
 				g.showOptions = true
 				g.needsRedraw = true
-			} else if g.asteroidArrowRect().Overlaps(pt) {
+			} else if g.asteroidInfoRect().Overlaps(pt) {
 				g.showAstMenu = true
 				g.needsRedraw = true
 			} else if g.helpRect().Overlaps(pt) {
@@ -1593,7 +1593,7 @@ iconsLoop:
 		} else if justPressed && g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showOptions = true
 			g.needsRedraw = true
-		} else if justPressed && g.asteroidArrowRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		} else if justPressed && g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showAstMenu = true
 			g.needsRedraw = true
 		} else if justPressed && g.clickLegend(mx, my) {
@@ -1911,6 +1911,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				aName = "Unknown"
 			}
 			astName := fmt.Sprintf("Asteroid: %s", aName)
+			rect := g.asteroidInfoRect()
+			drawFrame(screen, rect)
+
 			w, _ := textDimensions(astName)
 			x := g.width/2 - int(float64(w)*scale/2)
 			drawTextWithBGScale(screen, astName, x, int(30*scale), scale)


### PR DESCRIPTION
## Summary
- expand asteroid UI clickable area to cover coordinate and name
- draw a frame around the seed and asteroid label
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: `X11/extensions/Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fd997e7c832abe6144628715db9c