### PR TITLE
Fix item numbering after asteroid switch

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -200,6 +200,13 @@ func (g *Game) clickAsteroidMenu(mx, my int) bool {
 
 func (g *Game) loadAsteroid(ast Asteroid) {
 	g.asteroidID = ast.ID
+	// Reset cached legends so item numbering matches the newly loaded
+	// asteroid contents. These are rebuilt lazily when needed.
+	g.legendMap = nil
+	g.legendEntries = nil
+	g.legendColors = nil
+	g.selectedItem = -1
+	g.itemScroll = 0
 	bps := parseBiomePaths(ast.BiomePaths)
 	g.geysers = ast.Geysers
 	g.pois = ast.POIs

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060442"
+	ClientVersion    = "v0.0.6-2507060445"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15


### PR DESCRIPTION
## Summary
- reset cached legend data when loading a new asteroid so item numbers rebuild correctly
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_6869feb2d200832a9b70e059cf376bf8