### PR TITLE
Fix legend updates after asteroid change

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -199,6 +199,7 @@ func (g *Game) clickAsteroidMenu(mx, my int) bool {
 }
 
 func (g *Game) loadAsteroid(ast Asteroid) {
+	g.invalidateLegends()
 	g.asteroidID = ast.ID
 	// Reset cached legends so item numbering matches the newly loaded
 	// asteroid contents. These are rebuilt lazily when needed.

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060445"
+	ClientVersion    = "v0.0.6-2507060451"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -2355,6 +2355,12 @@ func main() {
 			_ = saveToFile(*out, jsonData)
 		}
 		ast := seed.Asteroids[astIdxSel]
+		game.invalidateLegends()
+		game.legendMap = nil
+		game.legendEntries = nil
+		game.legendColors = nil
+		game.selectedItem = -1
+		game.itemScroll = 0
 		game.asteroidID = ast.ID
 		bps := parseBiomePaths(ast.BiomePaths)
 		game.geysers = ast.Geysers


### PR DESCRIPTION
## Summary
- rebuild legends when asteroid is changed
- bump version

## Testing
- `go test -tags test ./...` *(fails: glfw requires DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6869fffd62dc832a90099e0e429b0924