### PR TITLE
Fix asteroid menu width overflow

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -99,7 +99,10 @@ func (g *Game) asteroidMenuSize() (int, int) {
 			maxW = w
 		}
 	}
-	w := maxW + 24
+	// Add extra space for the checkmark and some padding so
+	// longer names don't butt up against the right edge of the menu.
+	// Include an extra character width of padding for clarity.
+	w := maxW + 28 + LabelCharWidth
 	h := (len(g.asteroids)+1)*AsteroidMenuSpacing + 4
 	return w, h
 }

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060442"
+	ClientVersion    = "v0.0.6-2507060453"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15


### PR DESCRIPTION
## Summary
- account for checkmark width and add more padding in asteroid menu
- bump client version

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff8da7ec832aab5d969303903e6d