### PR TITLE
Fix legend visibility

### DIFF
--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060453"
+	ClientVersion    = "v0.0.6-2507060502"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -471,7 +471,7 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 	op.GeoM.Translate(math.Round(x), math.Round(y))
 	dst.DrawImage(g.legendImage, op)
 	lh := float64(g.legendImage.Bounds().Dy()) * scale
-	drawFrame(dst, image.Rect(int(math.Round(x)), int(math.Round(y)), int(math.Round(x+w)), int(math.Round(y+lh))))
+	strokeFrame(dst, image.Rect(int(math.Round(x)), int(math.Round(y)), int(math.Round(x+w)), int(math.Round(y+lh))))
 	if g.selectedItem >= 0 {
 		spacing := float64(rowSpacing())
 		hy := y + (10+spacing*float64(g.selectedItem+1))*scale
@@ -1953,7 +1953,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			lw := int(math.Round(float64(g.legend.Bounds().Dx()) * scale))
 			lh := int(math.Round(float64(g.legend.Bounds().Dy()) * scale))
 			ly := int(math.Round(-g.biomeScroll))
-			drawFrame(screen, image.Rect(0, ly, lw, ly+lh))
+			strokeFrame(screen, image.Rect(0, ly, lw, ly+lh))
 			if g.selectedBiome >= 0 {
 				spacing := float64(rowSpacing())
 				y0 := math.Round((10+spacing+spacing*float64(g.selectedBiome))*scale - g.biomeScroll)

--- a/ui.go
+++ b/ui.go
@@ -14,6 +14,12 @@ func drawFrame(dst *ebiten.Image, rect image.Rectangle) {
 	vector.StrokeRect(dst, float32(rect.Min.X)+0.5, float32(rect.Min.Y)+0.5, float32(rect.Dx())-1, float32(rect.Dy())-1, 1, buttonBorderColor, false)
 }
 
+// strokeFrame draws only the border using the global frame color without
+// filling the rectangle.
+func strokeFrame(dst *ebiten.Image, rect image.Rectangle) {
+	vector.StrokeRect(dst, float32(rect.Min.X)+0.5, float32(rect.Min.Y)+0.5, float32(rect.Dx())-1, float32(rect.Dy())-1, 1, buttonBorderColor, false)
+}
+
 // drawButton draws a rounded button. When active, the cyan color is used.
 func drawButton(dst *ebiten.Image, rect image.Rectangle, active bool) {
 	clr := buttonInactiveColor


### PR DESCRIPTION
## Summary
- stop using frame fill for legends
- adjust legend to draw border only so background isn't fully black
- bump ClientVersion

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a02c75508832aad1b6d2040723e43