### PR TITLE
Auto center on asteroid load

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 * Click the down-arrow next to the asteroid name to choose another asteroid.
 * A geyser icon opens a scrollable list of all geysers
   present on the map.
+* Newly loaded asteroids automatically center and zoom to fit the view.
 * Biome and item legend panels scroll when they extend past the window height,
   with extra space so items near the bottom can clear the icons.
 * Icons load asynchronously so the map is usable immediately.

--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -218,7 +218,7 @@ func (g *Game) loadAsteroid(ast Asteroid) {
 	g.astWidth = ast.SizeX
 	g.astHeight = ast.SizeY
 	g.legend, g.legendBiomes = buildLegendImage(bps)
-	g.centerAndFit()
+	g.fitOnLoad = true
 	g.biomeTextures = loadBiomeTextures()
 	names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
 	set := make(map[string]struct{})

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060453"
+	ClientVersion    = "v0.0.6-2507060503"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -849,6 +849,7 @@ type Game struct {
 	asteroidID        string
 	asteroidSpecified bool
 	statusError       bool
+	fitOnLoad         bool
 
 	textures      bool
 	vsync         bool
@@ -1102,6 +1103,12 @@ func (g *Game) startIconLoader(names []string) {
 
 func (g *Game) Update() error {
 	const panSpeed = PanSpeed
+
+	if g.fitOnLoad {
+		g.centerAndFit()
+		g.needsRedraw = true
+		g.fitOnLoad = false
+	}
 
 	if !g.smartRender {
 		g.needsRedraw = true
@@ -2390,7 +2397,7 @@ func main() {
 		game.astWidth = ast.SizeX
 		game.astHeight = ast.SizeY
 		game.legend, game.legendBiomes = buildLegendImage(bps)
-		game.centerAndFit()
+		game.fitOnLoad = true
 		game.biomeTextures = loadBiomeTextures()
 		names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
 		set := make(map[string]struct{})


### PR DESCRIPTION
## Summary
- center and zoom to fit after loading asteroids
- document auto-centering in README
- bump `ClientVersion`

## Testing
- `go test -tags test ./...` *(fails: `X11/extensions/Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a003e32ac832aa9741b9cd21d4d9b