### PR TITLE
Center items when clicked or tapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
   selecting image quality from low (2K) to high (8K) and includes a
   "Black and White" toggle for printing or color-blind accessibility.
 * Hover over geyser or POI icons to show an information panel.
-  Clicking pins the panel so it stays visible while panning.
+  Clicking or tapping centers the item and pins the panel so it stays visible
+  while panning.
 * Hover over the bottom icons for tooltips describing their actions. Tooltips
   automatically stay within the window bounds.
 * A help icon displays the available controls at any time. An X button closes the overlay.
@@ -44,7 +45,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 - **Mouse wheel or `+`/`-`** – zoom in and out.
 - **Drag with the mouse** – pan.
 - **Pinch gestures** – zoom on touch devices.
-- **Click or tap geysers/POIs** – view details in a popup.
+- **Click or tap geysers/POIs** – center the item and show details in a popup.
 - **Hover or tap legend entries** – highlight and select matching objects.
 - **Camera icon** – open the screenshot menu.
 - **Geyser icon** – show a list of all geysers.
@@ -108,8 +109,9 @@ the environments are:
   `asteroid=` ID.
 * **Mobile** – When running on a mobile OS or in a mobile browser the viewer
   disables item numbers at startup but the toolbar icons remain available.
-  Item details appear when the crosshair is centered over a geyser or POI or a
-  POI is tapped, and you pan or zoom using touch gestures.
+  Item details appear when the crosshair is centered over a geyser or POI or
+  when a POI is tapped, which also centers the item. You pan or zoom using touch
+  gestures.
 
 ## Saving Screenshots
 

--- a/const.go
+++ b/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ClientVersion    = "v0.0.6-2507060503"
+	ClientVersion    = "v0.0.6-2507060513"
 	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
 	AcceptCBORHeader = "application/cbor"
 	PanSpeed         = 15

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func init() {
 		{"Mouse wheel or +/-", "zoom in and out"},
 		{"Drag with the mouse/touch", "pan"},
 		{"Pinch with two fingers", "zoom on touch"},
-		{"Click or tap geysers/POIs", "show details"},
+		{"Click or tap geysers/POIs", "center and show details"},
 		{"Tap legend entries", "highlight items"},
 		{"Camera icon", "open screenshot menu"},
 		{"Geyser-icon", "list all geysers"},
@@ -1627,6 +1627,31 @@ iconsLoop:
 			g.dragging = false
 			g.showGeyserList = true
 			g.needsRedraw = true
+		} else if justPressed {
+			if info, ix, iy, icon, found := g.itemAt(mx, my); found {
+				g.camX += float64(g.width/2 - ix)
+				g.camY += float64(g.height/2 - iy)
+				g.clampCamera()
+
+				if max := g.maxBiomeScroll(); g.biomeScroll > max {
+					g.biomeScroll = max
+				}
+				if g.biomeScroll < 0 {
+					g.biomeScroll = 0
+				}
+				if max := g.maxItemScroll(); g.itemScroll > max {
+					g.itemScroll = max
+				}
+				if g.itemScroll < 0 {
+					g.itemScroll = 0
+				}
+
+				g.infoText = info
+				g.infoIcon = icon
+				g.showInfo = true
+				g.infoPinned = true
+				g.needsRedraw = true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- center a geyser or POI on click/tap and pin the info panel
- document new behavior in README and help text
- bump ClientVersion

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a05310040832a84c17307e920ab6d