### PR TITLE
Update font extraction script

### DIFF
--- a/scripts/extract_font.go
+++ b/scripts/extract_font.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/binary"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/image/font/opentype"
 )
 
 func main() {
@@ -40,7 +43,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := os.WriteFile(filepath.Clean(*outPath), data[start:end], 0o644); err != nil {
+	fontData := data[start:end]
+	font, err := opentype.Parse(fontData)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse font: %v\n", err)
+		os.Exit(1)
+	}
+	buf := &bytes.Buffer{}
+	if _, err := font.WriteSourceTo(nil, buf); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to copy font data: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Clean(*outPath), buf.Bytes(), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", *outPath, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- update `extract_font.go` to parse the font like the main program
- write back only the raw font bytes used at runtime

## Testing
- `bash scripts/install_deps.sh`
- `go test -tags test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686aabc53ad0832a9b287d9832c79cd3