### PR TITLE
Switch screenshot output to BMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ the environments are:
 ## Saving Screenshots
 
 Click the camera icon to open the screenshot menu. Choose a quality level
-(2K–8K) and the current view is written to a PNG named after the seed.
+(2K–8K) and the current view is written to a BMP named after the seed.
 After clicking **Save Screenshot** the button briefly shows *Taking Screenshot...*
 with a red outline before the menu closes automatically.
 You can also generate a screenshot non-interactively:
 
 ```bash
-go run . -coord SNDST-A-7-0-0-0 -screenshot myshot.png
+go run . -coord SNDST-A-7-0-0-0 -screenshot myshot.bmp
 ```
 
 ## Repository Layout

--- a/bmp/bmp.go
+++ b/bmp/bmp.go
@@ -1,0 +1,13 @@
+package bmp
+
+import (
+	"image"
+	"io"
+
+	"golang.org/x/image/bmp"
+)
+
+// Encode writes the Image m to w in BMP format.
+func Encode(w io.Writer, m image.Image) error {
+	return bmp.Encode(w, m)
+}

--- a/const.go
+++ b/const.go
@@ -34,7 +34,7 @@ const (
 	// LegendScrollExtraRows controls how many additional rows the legend
 	// panels can scroll beyond the bottom of the screen.
 	LegendScrollExtraRows = 3
-	ScreenshotFile        = "screenshot.png"
+	ScreenshotFile        = "screenshot.bmp"
 	HelpIconSize          = 24
 	HelpMargin            = 10
 	CrosshairSize         = 10

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/nfnt/bmp"
 	"image"
 	"image/color"
-	"image/png"
 	"math"
 	"os"
 	"time"
@@ -89,7 +89,7 @@ func (g *Game) captureScreen(screen *ebiten.Image) {
 	screen.ReadPixels(pixels)
 	img := &image.RGBA{Pix: pixels, Stride: 4 * b.Dx(), Rect: b}
 	if f, err := os.Create(g.screenshotPath); err == nil {
-		_ = png.Encode(f, img)
+		_ = bmp.Encode(f, img)
 		f.Close()
 	}
 	g.captured = true

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,11 @@ go 1.24.3
 require (
 	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/hajimehoshi/ebiten/v2 v2.8.8
-	golang.org/x/image v0.20.0
+       golang.org/x/image v0.20.0
+       github.com/nfnt/bmp v0.0.0
 )
+
+replace github.com/nfnt/bmp => ./bmp
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -5,9 +5,9 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/nfnt/bmp"
 	"image"
 	"image/color"
-	"image/png"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -153,8 +153,8 @@ func (g *Game) saveScreenshot() {
 	img := g.captureScreenshot(width, height, scale)
 	g.noColor = oldBW
 	var buf bytes.Buffer
-	_ = png.Encode(&buf, img)
-	name := fmt.Sprintf("%s-%s.png", g.coord, time.Now().Format("20060102-150405"))
+	_ = bmp.Encode(&buf, img)
+	name := fmt.Sprintf("%s-%s.bmp", g.coord, time.Now().Format("20060102-150405"))
 	_ = saveImageData(name, buf.Bytes())
 }
 


### PR DESCRIPTION
## Summary
- encode screenshots as BMP files
- create minimal bmp wrapper package
- update documentation for BMP screenshots

## Testing
- `go test -tags test ./...` *(fails: Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ac2fa8b60832abb98cd51e2e649a2