### PR TITLE
Add font minimization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ gofmt -w *.go
 go test -tags test ./...
 ```
 
+## Minimizing the Font
+
+The embedded `NotoSansMono.ttf` is about 1.7&nbsp;MB. Run the helper script to
+subset it to the ASCII range and shrink the binary size:
+
+```bash
+python3 scripts/minimize_font.py data/NotoSansMono.ttf data/NotoSansMono.ttf
+```
+The script requires the `fonttools` package (`pip install fonttools`) and
+overwrites the font in place. Use `git checkout -- data/NotoSansMono.ttf` to
+restore the original file.
+
 
 ## License
 

--- a/scripts/minimize_font.py
+++ b/scripts/minimize_font.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+from fontTools.ttLib import TTFont
+from fontTools.subset import Subsetter, Options
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Subset a TTF font to ASCII to reduce its size.")
+    parser.add_argument("src", help="input font file")
+    parser.add_argument("dest", help="output font file")
+    parser.add_argument(
+        "--extra", default="", help="additional characters to keep")
+    args = parser.parse_args()
+
+    # Load the font
+    font = TTFont(args.src)
+
+    # ASCII range plus any extra characters
+    chars = ''.join(chr(i) for i in range(32, 127)) + args.extra
+
+    options = Options()
+    subsetter = Subsetter(options=options)
+    subsetter.populate(text=chars)
+    subsetter.subset(font)
+
+    font.save(args.dest)
+
+    original = os.path.getsize(args.src)
+    new_size = os.path.getsize(args.dest)
+    print(
+        f"Wrote {args.dest} ({new_size/1024:.1f} KB, reduced from {original/1024:.1f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/text_stub.go
+++ b/text_stub.go
@@ -1,0 +1,26 @@
+//go:build test
+
+package main
+
+import (
+	"image/color"
+	"strings"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// Stubbed text helpers for tests. They avoid drawing but keep signatures.
+func drawText(dst *ebiten.Image, str string, x, y int) {}
+
+func drawTextColor(dst *ebiten.Image, str string, x, y int, clr color.Color) {}
+
+func textDimensions(str string) (int, int) {
+	lines := strings.Split(str, "\n")
+	width := 0
+	for _, l := range lines {
+		if len(l) > width {
+			width = len(l)
+		}
+	}
+	return width * LabelCharWidth, len(lines) * 20
+}


### PR DESCRIPTION
## Summary
- provide a Python helper that subsets the Noto font
- document the minimization step in the README
- add test build stubs for text helpers

## Testing
- `gofmt -w *.go */*.go`
- `go test -tags test ./...` *(fails: undefined identifiers in build)*

------
https://chatgpt.com/codex/tasks/task_e_686ac32ddadc832aa59de017351f4403