### PR TITLE
Remove redundant scale checks

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -12,16 +12,15 @@ import (
 )
 
 func (g *Game) asteroidArrowRect() image.Rectangle {
-	scale := g.uiScale()
 	name := g.asteroidID
 	if name == "" {
 		name = "Unknown"
 	}
 	text := "Asteroid: " + name
 	w, _ := textDimensions(text)
-	x := g.width/2 + int(float64(w)*scale/2) + int(4*scale)
-	size := int(12 * scale)
-	y := int(30*scale + 8*scale - float64(size)/2)
+	x := g.width/2 + w/2 + 4
+	size := 12
+	y := 30 + 8 - size/2
 	return image.Rect(x, y, x+size, y+size)
 }
 
@@ -32,10 +31,9 @@ func (g *Game) asteroidInfoRect() image.Rectangle {
 	if g.coord == "" {
 		return image.Rectangle{}
 	}
-	scale := g.uiScale()
 	sw, sh := textDimensions(g.coord)
-	sx := g.width/2 - int(float64(sw)*scale/2)
-	seedRect := image.Rect(sx-2, 10-2, sx-2+int(float64(sw+4)*scale), 10-2+int(float64(sh+4)*scale))
+	sx := g.width/2 - sw/2
+	seedRect := image.Rect(sx-2, 8, sx+sw+2, 8+sh+4)
 
 	name := g.asteroidID
 	if name == "" {
@@ -43,8 +41,8 @@ func (g *Game) asteroidInfoRect() image.Rectangle {
 	}
 	astText := "Asteroid: " + name
 	aw, ah := textDimensions(astText)
-	ax := g.width/2 - int(float64(aw)*scale/2)
-	astRect := image.Rect(ax-2, int(30*scale)-2, ax-2+int(float64(aw+4)*scale), int(30*scale)-2+int(float64(ah+4)*scale))
+	ax := g.width/2 - aw/2
+	astRect := image.Rect(ax-2, 28, ax+aw+2, 28+ah+4)
 
 	rect := seedRect.Union(astRect)
 	rect = rect.Union(g.asteroidArrowRect())
@@ -108,9 +106,6 @@ func (g *Game) asteroidMenuSize() (int, int) {
 
 func (g *Game) asteroidMenuRect() image.Rectangle {
 	w, h := g.asteroidMenuSize()
-	scale := g.uiScale()
-	w = int(float64(w) * scale)
-	h = int(float64(h) * scale)
 	ar := g.asteroidArrowRect()
 	x := ar.Min.X + ar.Dx()/2 - w/2
 	if x < 0 {
@@ -119,7 +114,7 @@ func (g *Game) asteroidMenuRect() image.Rectangle {
 	if x+w > g.width {
 		x = g.width - w
 	}
-	y := ar.Max.Y + int(4*scale)
+	y := ar.Max.Y + 4
 	if y+h > g.height {
 		y = g.height - h
 	}
@@ -128,8 +123,7 @@ func (g *Game) asteroidMenuRect() image.Rectangle {
 
 func (g *Game) maxAsteroidScroll() float64 {
 	_, h := g.asteroidMenuSize()
-	scale := g.uiScale()
-	max := float64(h)*scale - float64(g.height)
+	max := float64(h) - float64(g.height)
 	if max < 0 {
 		return 0
 	}
@@ -148,7 +142,6 @@ func (g *Game) adjustAsteroidScroll(d float64) {
 }
 
 func (g *Game) drawAsteroidMenu(dst *ebiten.Image) {
-	scale := g.uiScale()
 	rect := g.asteroidMenuRect()
 	w, h := g.asteroidMenuSize()
 	img := ebiten.NewImage(w, h)
@@ -166,7 +159,6 @@ func (g *Game) drawAsteroidMenu(dst *ebiten.Image) {
 		y += AsteroidMenuSpacing
 	}
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
 	dst.DrawImage(img, op)
 }
@@ -176,9 +168,8 @@ func (g *Game) clickAsteroidMenu(mx, my int) bool {
 	if !rect.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		return false
 	}
-	scale := g.uiScale()
-	x := int(float64(mx-rect.Min.X) / scale)
-	y := int(float64(my-rect.Min.Y)/scale) + int(g.asteroidScroll)
+	x := mx - rect.Min.X
+	y := my - rect.Min.Y + int(g.asteroidScroll)
 	mx = x
 	my = y
 	w, _ := g.asteroidMenuSize()

--- a/draw.go
+++ b/draw.go
@@ -195,31 +195,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			labels = append(labels, label{formatted, int(x) - int(float64(width)*fs/2), int(y) + 4, width, labelClr})
 		}
 
-		labelScale := g.uiScale()
 		fs := fontScale()
 		for _, l := range labels {
 			x := l.x
-			if labelScale != 1.0 {
-				x -= int(float64(l.width) * fs * (labelScale - 1) / 2)
-			}
 			if l.clr.A != 0 {
-				if labelScale == 1.0 {
-					drawTextWithBGBorder(screen, l.text, x, l.y, l.clr)
-				} else {
-					drawTextWithBGBorderScale(screen, l.text, x, l.y, l.clr, labelScale)
-				}
+				drawTextWithBGBorderScale(screen, l.text, x, l.y, l.clr, 1)
 			} else {
-				if labelScale == 1.0 {
-					drawTextWithBG(screen, l.text, x, l.y)
-				} else {
-					drawTextWithBGScale(screen, l.text, x, l.y, labelScale)
-				}
+				drawTextWithBGScale(screen, l.text, x, l.y, 1)
 			}
 		}
 
 		if g.coord != "" && !g.screenshotMode {
 			label := g.coord
-			scale := g.uiScale()
 			aName := g.asteroidID
 			if aName == "" {
 				aName = "Unknown"
@@ -227,14 +214,14 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			astName := fmt.Sprintf("Asteroid: %s", aName)
 
 			w, _ := textDimensions(astName)
-			x := g.width/2 - int(float64(w)*scale/2)
-			drawTextWithBGScale(screen, astName, x, int(30*scale), scale)
+			x := g.width/2 - w/2
+			drawTextWithBGScale(screen, astName, x, 30, 1)
 			ar := g.asteroidArrowRect()
 			drawDownArrow(screen, ar, g.showAstMenu)
 
 			w, _ = textDimensions(label)
-			x = g.width/2 - int(float64(w)*scale/2)
-			drawTextWithBGScale(screen, label, x, 10, scale)
+			x = g.width/2 - w/2
+			drawTextWithBGScale(screen, label, x, 10, 1)
 		}
 
 		if g.showLegend {
@@ -242,8 +229,6 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				g.legend, g.legendBiomes = buildLegendImage(g.biomes)
 			}
 			opLegend := &ebiten.DrawImageOptions{}
-			scale := g.uiScale()
-			opLegend.GeoM.Scale(scale, scale)
 			opLegend.GeoM.Translate(0, -g.biomeScroll)
 			screen.DrawImage(g.legend, opLegend)
 			if g.selectedBiome >= 0 {
@@ -323,16 +308,15 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			vector.StrokeCircle(screen, gcx, gcy, float32(size)/2, 1, buttonBorderColor, true)
 
 			if g.hoverIcon != hoverNone {
-				scale := g.uiScale()
 				switch g.hoverIcon {
 				case hoverScreenshot:
-					g.drawTooltip(screen, "Screenshot", sr, scale)
+					g.drawTooltip(screen, "Screenshot", sr, 1)
 				case hoverHelp:
-					g.drawTooltip(screen, "Help", hr, scale)
+					g.drawTooltip(screen, "Help", hr, 1)
 				case hoverOptions:
-					g.drawTooltip(screen, "Options", or, scale)
+					g.drawTooltip(screen, "Options", or, 1)
 				case hoverGeysers:
-					g.drawTooltip(screen, "Geyser List", gr, scale)
+					g.drawTooltip(screen, "Geyser List", gr, 1)
 				}
 			}
 		}
@@ -431,25 +415,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 		}
 		if len(highlightLabels) > 0 {
-			labelScale := g.uiScale()
-			fs := fontScale()
 			for _, l := range highlightLabels {
-				x := l.x
-				if labelScale != 1.0 {
-					x -= int(float64(l.width) * fs * (labelScale - 1) / 2)
-				}
 				if l.clr.A != 0 {
-					if labelScale == 1.0 {
-						drawTextWithBGBorder(screen, l.text, x, l.y, l.clr)
-					} else {
-						drawTextWithBGBorderScale(screen, l.text, x, l.y, l.clr, labelScale)
-					}
+					drawTextWithBGBorderScale(screen, l.text, l.x, l.y, l.clr, 1)
 				} else {
-					if labelScale == 1.0 {
-						drawTextWithBG(screen, l.text, x, l.y)
-					} else {
-						drawTextWithBGScale(screen, l.text, x, l.y, labelScale)
-					}
+					drawTextWithBGScale(screen, l.text, l.x, l.y, 1)
 				}
 			}
 		}

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -25,12 +25,10 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		worldX := int(math.Round(((float64(cx) - g.camX) / g.zoom) / 2))
 		worldY := int(math.Round(((float64(cy) - g.camY) / g.zoom) / 2))
 		coords := fmt.Sprintf("X: %d Y: %d", worldX, worldY)
-		scale := g.uiScale()
-		drawTextWithBGScale(screen, coords, 5, g.height-int(20*scale), scale)
+		drawTextWithBGScale(screen, coords, 5, g.height-20, 1)
 	}
 
 	if g.showInfo {
-		scale := g.uiScale()
 		w, h := textDimensions(g.infoText)
 		iconW, iconH := 0, 0
 		if g.infoIcon != nil {
@@ -42,9 +40,9 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		if iconH > h {
 			panelH = iconH
 		}
-		tx := g.width/2 - int(float64(panelW)*scale)/2
-		ty := g.height - int(float64(panelH)*scale) - 30
-		g.drawInfoPanel(screen, g.infoText, g.infoIcon, tx, ty, scale)
+		tx := g.width/2 - panelW/2
+		ty := g.height - panelH - 30
+		g.drawInfoPanel(screen, g.infoText, g.infoIcon, tx, ty)
 	}
 
 	if g.showShotMenu {
@@ -57,10 +55,9 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		g.drawAsteroidMenu(screen)
 	}
 	if g.showHelp && !g.screenshotMode {
-		scale := g.uiScale()
 		rect := g.helpMenuRect()
 		drawFrame(screen, rect)
-		drawTextScale(screen, helpMessage, rect.Min.X+2, rect.Min.Y+2, scale)
+		drawTextScale(screen, helpMessage, rect.Min.X+2, rect.Min.Y+2, 1)
 		cr := g.helpCloseRect()
 		drawCloseButton(screen, cr)
 	}

--- a/drawing.go
+++ b/drawing.go
@@ -14,21 +14,11 @@ func drawTextWithBG(dst *ebiten.Image, text string, x, y int) {
 	drawText(dst, text, x, y)
 }
 
-func drawTextWithBGScale(dst *ebiten.Image, text string, x, y int, scale float64) {
-	if scale == 1.0 {
-		drawTextWithBG(dst, text, x, y)
-		return
-	}
-	w, h := textDimensions(text)
-	w += 4
-	h += 4
-	img := ebiten.NewImage(w, h)
-	vector.DrawFilledRect(img, 0, 0, float32(w), float32(h), color.RGBA{0, 0, 0, 128}, false)
-	drawText(img, text, 2, 2)
-	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
-	op.GeoM.Translate(float64(x-2), float64(y-2))
-	dst.DrawImage(img, op)
+// drawTextWithBG draws text with a translucent background.
+// Previously this supported arbitrary scaling, but the UI no longer scales,
+// so this helper simply draws at the current font size.
+func drawTextWithBGScale(dst *ebiten.Image, text string, x, y int, _ float64) {
+	drawTextWithBG(dst, text, x, y)
 }
 
 func drawTextWithBGBorder(dst *ebiten.Image, text string, x, y int, border color.Color) {
@@ -42,39 +32,15 @@ func drawTextWithBGBorder(dst *ebiten.Image, text string, x, y int, border color
 	drawText(dst, text, x, y)
 }
 
-func drawTextWithBGBorderScale(dst *ebiten.Image, text string, x, y int, border color.Color, scale float64) {
-	if scale == 1.0 {
-		drawTextWithBGBorder(dst, text, x, y, border)
-		return
-	}
-	w, h := textDimensions(text)
-	w += 4
-	h += 4
-	img := ebiten.NewImage(w+2, h+2)
-	vector.DrawFilledRect(img, 0, 0, float32(w+2), float32(h+2), border, false)
-	vector.DrawFilledRect(img, 1, 1, float32(w), float32(h), color.RGBA{0, 0, 0, 128}, false)
-	drawText(img, text, 3, 3)
-	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
-	op.GeoM.Translate(float64(x-2), float64(y-2))
-	dst.DrawImage(img, op)
+func drawTextWithBGBorderScale(dst *ebiten.Image, text string, x, y int, border color.Color, _ float64) {
+	drawTextWithBGBorder(dst, text, x, y, border)
 }
 
-func drawTextScale(dst *ebiten.Image, text string, x, y int, scale float64) {
-	if scale == 1.0 {
-		drawText(dst, text, x, y)
-		return
-	}
-	w, h := textDimensions(text)
-	img := ebiten.NewImage(w, h)
-	drawText(img, text, 0, 0)
-	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
-	op.GeoM.Translate(float64(x), float64(y))
-	dst.DrawImage(img, op)
+func drawTextScale(dst *ebiten.Image, text string, x, y int, _ float64) {
+	drawText(dst, text, x, y)
 }
 
-func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image, x, y int, scale float64) {
+func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image, x, y int) {
 	txtW, txtH := textDimensions(text)
 	iconW, iconH := 0, 0
 	if icon != nil {
@@ -100,12 +66,11 @@ func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image,
 	}
 	drawText(img, text, iconW+gap+4, 4)
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(float64(x-4), float64(y-4))
 	dst.DrawImage(img, op)
 }
 
-func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x, y int, scale float64) {
+func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x, y int) {
 	txtW, txtH := textDimensions(text)
 	iconW, iconH := 0, 0
 	if icon != nil {
@@ -118,18 +83,6 @@ func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x
 	if iconH > txtH {
 		h = iconH
 	}
-	if scale == 1.0 {
-		if icon != nil {
-			opIcon := &ebiten.DrawImageOptions{Filter: g.filterMode()}
-			sc := float64(InfoIconSize) / math.Max(float64(icon.Bounds().Dx()), float64(icon.Bounds().Dy()))
-			opIcon.GeoM.Scale(sc, sc)
-			opIcon.GeoM.Translate(float64(x), float64(y+(h-iconH)/2))
-			dst.DrawImage(icon, opIcon)
-		}
-		drawText(dst, text, x+iconW+gap, y+(h-txtH)/2)
-		return
-	}
-
 	img := ebiten.NewImage(w, h)
 	if icon != nil {
 		opIcon := &ebiten.DrawImageOptions{Filter: g.filterMode()}
@@ -140,7 +93,6 @@ func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x
 	}
 	drawText(img, text, iconW+gap, (h-txtH)/2)
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(float64(x), float64(y))
 	dst.DrawImage(img, op)
 }

--- a/fonts.go
+++ b/fonts.go
@@ -13,7 +13,10 @@ import (
 //go:embed data/NotoSansMono.ttf
 var notoTTF []byte
 
-const baseFontSize = 12.0
+const (
+	baseFontSize       = 12.0
+	screenshotFontSize = 14.0
+)
 
 var (
 	notoFont   font.Face

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -117,25 +117,9 @@ type loadedIcon struct {
 	img  *ebiten.Image
 }
 
-func (g *Game) uiScale() float64 {
-	if g.mobile {
-		return 1.0
-	}
-	if g.screenshotMode {
-		if g.height > 1700 {
-			return 4.0
-		}
-		if g.height > 850 {
-			return 2.0
-		}
-		return 1.0
-	}
-	return 1.0
-}
+func (g *Game) uiScale() float64 { return 1.0 }
 
-func (g *Game) iconSize() int {
-	return int(float64(HelpIconSize) * g.uiScale())
-}
+func (g *Game) iconSize() int { return HelpIconSize }
 
 func (g *Game) filterMode() ebiten.Filter {
 	if g.linearFilter {
@@ -189,9 +173,6 @@ func helpMenuSize() (int, int) {
 
 func (g *Game) helpMenuRect() image.Rectangle {
 	w, h := helpMenuSize()
-	scale := g.uiScale()
-	w = int(float64(w) * scale)
-	h = int(float64(h) * scale)
 	r := g.helpRect()
 	x := r.Max.X - w
 	if x < 0 {

--- a/legend.go
+++ b/legend.go
@@ -118,29 +118,26 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 		drawTextWithBGBorder(img, "Clear", 5, y, buttonBorderColor)
 		g.legendImage = img
 	}
-	scale := g.uiScale()
-	w := float64(g.legendImage.Bounds().Dx()) * scale
+	w := float64(g.legendImage.Bounds().Dx())
 	x := float64(dst.Bounds().Dx()) - w - 12
 	y := 10.0 - g.itemScroll
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(math.Round(x), math.Round(y))
 	dst.DrawImage(g.legendImage, op)
 	if g.selectedItem >= 0 {
 		spacing := float64(rowSpacing())
-		hy := y + (10+spacing*float64(g.selectedItem+1))*scale
-		hh := spacing * scale
+		hy := y + (10 + spacing*float64(g.selectedItem+1))
+		hh := spacing
 		vector.StrokeRect(dst, float32(math.Round(x))+0.5, float32(math.Round(hy))-4, float32(math.Round(w))-1, float32(math.Round(hh))-1, 2, color.RGBA{255, 0, 0, 255}, false)
 	}
 }
 
 func (g *Game) drawGeyserList(dst *ebiten.Image) {
 	vector.DrawFilledRect(dst, 0, 0, float32(g.width), float32(g.height), color.RGBA{0, 0, 0, 255}, false)
-	scale := g.uiScale()
 	cr := g.geyserCloseRect()
 	drawCloseButton(dst, cr)
 
-	spacing := int(10 * scale)
+	spacing := 10
 	type item struct {
 		text string
 		icon *ebiten.Image
@@ -156,12 +153,10 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 		}
 		txt := displayGeyser(gy.ID) + "\n" + formatGeyserInfo(gy)
 		w, h := infoRowSize(txt, ic)
-		sw := int(float64(w) * scale)
-		sh := int(float64(h) * scale)
-		if sw > maxW {
-			maxW = sw
+		if w > maxW {
+			maxW = w
 		}
-		items[i] = item{text: txt, icon: ic, w: sw, h: sh}
+		items[i] = item{text: txt, icon: ic, w: w, h: h}
 	}
 	cols := 1
 	if maxW+spacing > 0 {
@@ -184,7 +179,7 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 		x := spacing
 		for c := 0; c < cols && idx < len(items); c++ {
 			it := items[idx]
-			g.drawInfoRow(dst, it.text, it.icon, x, y, scale)
+			g.drawInfoRow(dst, it.text, it.icon, x, y)
 			x += maxW + spacing
 			idx++
 		}
@@ -193,8 +188,7 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 }
 
 func (g *Game) maxGeyserScroll() float64 {
-	scale := g.uiScale()
-	spacing := int(10 * scale)
+	spacing := 10
 	type item struct {
 		w int
 		h int
@@ -208,12 +202,10 @@ func (g *Game) maxGeyserScroll() float64 {
 		}
 		txt := displayGeyser(gy.ID) + "\n" + formatGeyserInfo(gy)
 		w, h := infoRowSize(txt, ic)
-		sw := int(float64(w) * scale)
-		sh := int(float64(h) * scale)
-		if sw > maxW {
-			maxW = sw
+		if w > maxW {
+			maxW = w
 		}
-		items[i] = item{w: sw, h: sh}
+		items[i] = item{w: w, h: h}
 	}
 	cols := 1
 	if maxW+spacing > 0 {
@@ -259,9 +251,8 @@ func (g *Game) maxBiomeScroll() float64 {
 	if g.legend == nil {
 		return 0
 	}
-	scale := g.uiScale()
-	h := float64(g.legend.Bounds().Dy()) * scale
-	extra := float64(rowSpacing()*LegendScrollExtraRows) * scale
+	h := float64(g.legend.Bounds().Dy())
+	extra := float64(rowSpacing() * LegendScrollExtraRows)
 	max := h - float64(g.height) + extra
 	if max < 0 {
 		max = 0
@@ -273,9 +264,8 @@ func (g *Game) maxItemScroll() float64 {
 	if g.legendImage == nil {
 		return 0
 	}
-	scale := g.uiScale()
-	h := float64(g.legendImage.Bounds().Dy()) * scale
-	extra := float64(rowSpacing()*LegendScrollExtraRows) * scale
+	h := float64(g.legendImage.Bounds().Dy())
+	extra := float64(rowSpacing() * LegendScrollExtraRows)
 	max := h + 10 - float64(g.height) + extra
 	if max < 0 {
 		max = 0
@@ -298,13 +288,12 @@ func (g *Game) updateHover(mx, my int) {
 		}
 		return
 	}
-	scale := g.uiScale()
 	if g.legend != nil && len(g.legendBiomes) > 0 {
-		w := int(float64(g.legend.Bounds().Dx()) * scale)
+		w := g.legend.Bounds().Dx()
 		if mx >= 0 && mx < w {
 			spacing := float64(rowSpacing())
-			baseY := int((10+spacing)*scale) - int(g.biomeScroll)
-			rowH := int(spacing * scale)
+			baseY := int(10+spacing) - int(g.biomeScroll)
+			rowH := int(spacing)
 			for i := range g.legendBiomes {
 				ry := baseY + i*rowH
 				if my >= ry && my < ry+rowH {
@@ -322,12 +311,12 @@ func (g *Game) updateHover(mx, my int) {
 	}
 	useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 	if useNumbers && g.legendImage != nil {
-		w := int(float64(g.legendImage.Bounds().Dx()) * scale)
+		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12
 		if mx >= x0 && mx < x0+w {
 			spacing := float64(rowSpacing())
-			baseY := int((10+spacing)*scale) - int(g.itemScroll)
-			rowH := int(spacing * scale)
+			baseY := int(10+spacing) - int(g.itemScroll)
+			rowH := int(spacing)
 			for i := range g.legendEntries {
 				ry := baseY + i*rowH
 				if my >= ry && my < ry+rowH {
@@ -378,13 +367,12 @@ func (g *Game) clickLegend(mx, my int) bool {
 		return false
 	}
 	handled := false
-	scale := g.uiScale()
 	if g.legend != nil && len(g.legendBiomes) > 0 {
-		w := int(float64(g.legend.Bounds().Dx()) * scale)
+		w := g.legend.Bounds().Dx()
 		if mx >= 0 && mx < w {
 			spacing := float64(rowSpacing())
-			baseY := int((10+spacing)*scale) - int(g.biomeScroll)
-			rowH := int(spacing * scale)
+			baseY := int(10+spacing) - int(g.biomeScroll)
+			rowH := int(spacing)
 			count := len(g.legendBiomes)
 			for i := 0; i <= count; i++ {
 				ry := baseY + i*rowH
@@ -402,12 +390,12 @@ func (g *Game) clickLegend(mx, my int) bool {
 	}
 	useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 	if useNumbers && g.legendImage != nil {
-		w := int(float64(g.legendImage.Bounds().Dx()) * scale)
+		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12
 		if mx >= x0 && mx < x0+w {
 			spacing := float64(rowSpacing())
-			baseY := int((10+spacing)*scale) - int(g.itemScroll)
-			rowH := int(spacing * scale)
+			baseY := int(10+spacing) - int(g.itemScroll)
+			rowH := int(spacing)
 			count := len(g.legendEntries)
 			for i := 0; i <= count; i++ {
 				ry := baseY + i*rowH

--- a/options_menu.go
+++ b/options_menu.go
@@ -46,10 +46,7 @@ func (g *Game) optionsMenuSize() (int, int) {
 
 func (g *Game) optionsMenuRect() image.Rectangle {
 	w, h := g.optionsMenuSize()
-	scale := g.uiScale()
-	w = int(float64(w) * scale)
-	h = int(float64(h) * scale)
-	x := g.optionsRect().Min.X - w - int(10*scale)
+	x := g.optionsRect().Min.X - w - 10
 	if x < 0 {
 		x = 0
 	}
@@ -61,7 +58,6 @@ func (g *Game) optionsMenuRect() image.Rectangle {
 }
 
 func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
-	scale := g.uiScale()
 	rect := g.optionsMenuRect()
 	w, h := g.optionsMenuSize()
 	img := ebiten.NewImage(w, h)
@@ -125,7 +121,6 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawText(img, "Close", btn.Min.X+6, btn.Min.Y+4)
 
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
 	dst.DrawImage(img, op)
 }
@@ -135,9 +130,8 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	if !rect.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		return false
 	}
-	scale := g.uiScale()
-	x := int(float64(mx-rect.Min.X) / scale)
-	y := int(float64(my-rect.Min.Y) / scale)
+	x := mx - rect.Min.X
+	y := my - rect.Min.Y
 	mx = x
 	my = y
 	w, _ := g.optionsMenuSize()

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -40,10 +40,7 @@ func (g *Game) screenshotMenuSize() (int, int) {
 
 func (g *Game) screenshotMenuRect() image.Rectangle {
 	w, h := g.screenshotMenuSize()
-	scale := g.uiScale()
-	w = int(float64(w) * scale)
-	h = int(float64(h) * scale)
-	x := g.screenshotRect().Min.X - w - int(10*scale)
+	x := g.screenshotRect().Min.X - w - 10
 	if x < 0 {
 		x = 0
 	}
@@ -55,7 +52,6 @@ func (g *Game) screenshotMenuRect() image.Rectangle {
 }
 
 func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
-	scale := g.uiScale()
 	rect := g.screenshotMenuRect()
 	w, h := g.screenshotMenuSize()
 	img := ebiten.NewImage(w, h)
@@ -99,7 +95,6 @@ func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
 		}
 	}
 	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Scale(scale, scale)
 	op.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))
 	dst.DrawImage(img, op)
 }
@@ -109,9 +104,8 @@ func (g *Game) clickScreenshotMenu(mx, my int) bool {
 	if !rect.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		return false
 	}
-	scale := g.uiScale()
-	x := int(float64(mx-rect.Min.X) / scale)
-	y := int(float64(my-rect.Min.Y) / scale)
+	x := mx - rect.Min.X
+	y := my - rect.Min.Y
 	mx = x
 	my = y
 	items := append([]string(nil), ScreenshotQualities...)
@@ -175,6 +169,8 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	g.camX = 0
 	g.camY = 0
 	g.screenshotMode = true
+	oldSize := fontSize
+	setFontSize(screenshotFontSize)
 	img := ebiten.NewImage(w, h)
 	g.needsRedraw = true
 	g.Draw(img)
@@ -182,6 +178,7 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	pix := make([]byte, 4*b.Dx()*b.Dy())
 	img.ReadPixels(pix)
 	rgba := &image.RGBA{Pix: pix, Stride: 4 * b.Dx(), Rect: b}
+	setFontSize(oldSize)
 	g.screenshotMode = false
 	g.width = ow
 	g.height = oh

--- a/touch_input.go
+++ b/touch_input.go
@@ -36,16 +36,15 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 				g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 				g.touchUI = true
 			} else {
-				scale := g.uiScale()
 				if g.legend != nil {
-					lw := int(float64(g.legend.Bounds().Dx()) * scale)
+					lw := g.legend.Bounds().Dx()
 					if x >= 0 && x < lw {
 						g.touchUI = true
 					}
 				}
 				useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 				if !g.touchUI && useNumbers && g.legendImage != nil {
-					lw := int(float64(g.legendImage.Bounds().Dx()) * scale)
+					lw := g.legendImage.Bounds().Dx()
 					x0 := g.width - lw - 12
 					if x >= x0 && x < x0+lw {
 						g.touchUI = true
@@ -68,9 +67,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 				if g.showGeyserList {
 					g.adjustGeyserScroll(-float64(dy))
 				} else {
-					scale := g.uiScale()
 					if g.legend != nil {
-						lw := int(float64(g.legend.Bounds().Dx()) * scale)
+						lw := g.legend.Bounds().Dx()
 						if g.touchStartX >= 0 && g.touchStartX < lw {
 							g.biomeScroll -= float64(dy)
 							if g.biomeScroll < 0 {
@@ -84,7 +82,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					}
 					useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if useNumbers && g.legendImage != nil {
-						lw := int(float64(g.legendImage.Bounds().Dx()) * scale)
+						lw := g.legendImage.Bounds().Dx()
 						x0 := g.width - lw - 12
 						if g.touchStartX >= x0 && g.touchStartX < x0+lw {
 							g.itemScroll -= float64(dy)
@@ -120,16 +118,15 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 					g.touchUI = true
 				} else {
-					scale := g.uiScale()
 					if g.legend != nil {
-						lw := int(float64(g.legend.Bounds().Dx()) * scale)
+						lw := g.legend.Bounds().Dx()
 						if x >= 0 && x < lw {
 							g.touchUI = true
 						}
 					}
 					useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if !g.touchUI && useNumbers && g.legendImage != nil {
-						lw := int(float64(g.legendImage.Bounds().Dx()) * scale)
+						lw := g.legendImage.Bounds().Dx()
 						x0 := g.width - lw - 12
 						if x >= x0 && x < x0+lw {
 							g.touchUI = true

--- a/update.go
+++ b/update.go
@@ -91,11 +91,10 @@ func (g *Game) Update() error {
 			g.adjustGeyserScroll(-float64(wheelY) * 10)
 		} else {
 			handled := false
-			scale := g.uiScale()
 			useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
 			if g.legend != nil {
-				lw := int(float64(g.legend.Bounds().Dx()) * scale)
-				lh := int(float64(g.legend.Bounds().Dy()) * scale)
+				lw := g.legend.Bounds().Dx()
+				lh := g.legend.Bounds().Dy()
 				if lh > g.height && mxTmp >= 0 && mxTmp < lw {
 					g.biomeScroll -= float64(wheelY) * 10
 					if g.biomeScroll < 0 {
@@ -110,8 +109,8 @@ func (g *Game) Update() error {
 				}
 			}
 			if !handled && useNumbers && g.legendImage != nil {
-				lw := int(float64(g.legendImage.Bounds().Dx()) * scale)
-				lh := int(float64(g.legendImage.Bounds().Dy()) * scale)
+				lw := g.legendImage.Bounds().Dx()
+				lh := g.legendImage.Bounds().Dy()
 				x0 := g.width - lw - 12
 				if lh+10 > g.height && mxTmp >= x0 && mxTmp < x0+lw {
 					g.itemScroll -= float64(wheelY) * 10

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -151,17 +151,9 @@ func (g *Game) drawLoadingScreen(dst *ebiten.Image) bool {
 	x := g.width/2 - int(float64(w)*scale/2)
 	y := g.height/2 - int(float64(h)*scale/2)
 	if g.statusError {
-		if scale == 1.0 {
-			drawTextWithBGBorder(dst, msg, x, y, errorBorderColor)
-		} else {
-			drawTextWithBGBorderScale(dst, msg, x, y, errorBorderColor, scale)
-		}
+		drawTextWithBGBorderScale(dst, msg, x, y, errorBorderColor, scale)
 	} else {
-		if scale == 1.0 {
-			drawTextWithBG(dst, msg, x, y)
-		} else {
-			drawTextWithBGScale(dst, msg, x, y, scale)
-		}
+		drawTextWithBGScale(dst, msg, x, y, scale)
 	}
 	g.lastDraw = time.Now()
 	return true


### PR DESCRIPTION
## Summary
- drop uiScale logic and unused scaling branches
- remove scaling from menus and labels
- enlarge fonts to 14pt when capturing screenshots

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ac582a064832a8f9b5bc5faedb5fa