### PR TITLE
Switch to Brotli for wasm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Run the build script to compile the program and copy the necessary runtime files
 ./scripts/build_all.sh
 ```
 
-Open `build/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons and now includes an optional field to choose the asteroid ID. Valid seeds redirect to `view.html` which loads `oni-view.wasm.gz` and decompresses it with [Pako](https://github.com/nodeca/pako).
+Open `build/index.html` in a browser to enter a seed. The page has a dark themed form with Material icons and now includes an optional field to choose the asteroid ID. Valid seeds redirect to `view.html` which loads `oni-view.wasm.br` and decompresses it with [brotli-dec-wasm](https://github.com/httptoolkit/brotli-wasm).
 You can also provide the seed in the index page URL with `index.html?coord=<seed>` or `index.html#coord=<seed>` (just `#<seed>` works too) and it will forward you to the viewer automatically. You can still specify the seed coordinate directly in the viewer URL using `view.html?coord=<seed>` or `view.html#coord=<seed>`. Add `asteroid=<id>` to select a different asteroid when a seed contains multiple. When an asteroid ID is provided the viewer shows it after the seed as `Asteroid: <id>` with a small arrow for opening the asteroid list. If the ID is not valid the viewer displays the coordinates and asteroid ID with `This location does not contain Asteroid ID: <id>`. When asteroids are present they are listed under `Valid IDs:` with a newline after every third ID.
 
 ## Desktop vs Web and Mobile

--- a/html/view.html
+++ b/html/view.html
@@ -59,8 +59,8 @@
     }
   </style>
   <script src="wasm_exec.js"></script>
-  <script src="https://unpkg.com/pako@2.1.0/dist/pako.min.js"></script>
-  <script>
+  <script type="module">
+    import brotliPromise from 'https://unpkg.com/brotli-dec-wasm@2.3.0/index.js?module';
     if (!WebAssembly.instantiateStreaming) {
       WebAssembly.instantiateStreaming = async (resp, importObject) => {
         const source = await (await resp).arrayBuffer();
@@ -68,7 +68,8 @@
       };
     }
     const go = new Go();
-    fetch("oni-view.wasm.gz")
+    const brotli = await brotliPromise;
+    fetch("oni-view.wasm.br")
       .then(async (resp) => {
         const total = parseInt(resp.headers.get("content-length") || "0", 10);
         let buf;
@@ -106,7 +107,7 @@
           }
           document.getElementById("speed").textContent = "Loading application.";
         }
-        const decompressed = pako.ungzip(new Uint8Array(buf)).buffer;
+        const decompressed = brotli.decompress(new Uint8Array(buf)).buffer;
         return WebAssembly.instantiate(decompressed, go.importObject);
       })
       .then((result) => {

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -18,8 +18,8 @@ env CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -ldflags="-s -w" -trimpath -build
 #    build/oni-view.wasm -o build/oni-view.wasm
 #fi
 
-# Compress the WASM to reduce size.
-gzip -9 -c build/oni-view.wasm > build/oni-view.wasm.gz
+# Compress the WASM to reduce size using Brotli.
+brotli -f -q 11 build/oni-view.wasm -o build/oni-view.wasm.br
 rm build/oni-view.wasm
 
 # Copy the JS runtime and HTML loader for WASM builds.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -8,7 +8,7 @@ sudo apt-get update
 sudo apt-get install -y git curl build-essential pkg-config \
     libasound2-dev libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
     libxcursor-dev libxi-dev libxrender-dev libxxf86vm-dev \
-    libgl1-mesa-dev libgl1 xorg-dev xvfb webp binaryen
+    libgl1-mesa-dev libgl1 xorg-dev xvfb webp binaryen brotli
 
 # Install Go 1.24.3 if not already available.
 if ! go version 2>/dev/null | grep -q "go1.24.3"; then


### PR DESCRIPTION
## Summary
- use Brotli compression when building the wasm module
- install Brotli via `install_deps.sh`
- update viewer to load `oni-view.wasm.br` and decompress with `brotli-dec-wasm`
- document Brotli in README

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ac95fde28832abbb7378e64228652