### PR TITLE
Fix label centering with font scaling

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -146,7 +146,7 @@ func (g *Game) drawAsteroidMenu(dst *ebiten.Image) {
 	w, h := g.asteroidMenuSize()
 	img := ebiten.NewImage(w, h)
 	drawFrame(img, image.Rect(0, 0, w, h))
-	drawText(img, AsteroidMenuTitle, 6, 6)
+	drawText(img, AsteroidMenuTitle, 6, 6, false)
 	y := 6 + AsteroidMenuSpacing - int(g.asteroidScroll)
 	for _, a := range g.asteroids {
 		btn := image.Rect(4, y-4, w-4, y-4+22)
@@ -155,7 +155,7 @@ func (g *Game) drawAsteroidMenu(dst *ebiten.Image) {
 			ck := image.Rect(btn.Min.X+4, btn.Min.Y+4, btn.Min.X+16, btn.Min.Y+16)
 			drawCheck(img, ck)
 		}
-		drawText(img, a.ID, btn.Min.X+20, btn.Min.Y+4)
+		drawText(img, a.ID, btn.Min.X+20, btn.Min.Y+4, false)
 		y += AsteroidMenuSpacing
 	}
 	op := &ebiten.DrawImageOptions{}

--- a/draw.go
+++ b/draw.go
@@ -79,7 +79,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			y := math.Round((float64(gy.Y) * 2 * g.zoom) + g.camY)
 
 			name := displayGeyser(gy.ID)
-			formatted, width := formatLabel(name)
+			formatted, _ := formatLabel(name)
 			dotClr := color.RGBA{}
 			if idx, ok := g.legendMap["g"+name]; ok && idx-1 < len(g.legendColors) {
 				dotClr = g.legendColors[idx-1]
@@ -112,12 +112,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					}
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["g"+name])
-						width = len(formatted)
 					}
 					if g.showItemNames || useNumbers {
 						if g.showItemNames || useNumbers {
-							fs := fontScale()
-							labels = append(labels, label{formatted, int(x) - int(float64(width)*fs/2), int(y+h/2) + 2, width, labelClr})
+							labels = append(labels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
 						}
 					}
 					continue
@@ -130,12 +128,10 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["g"+name])
-				width = len(formatted)
 			}
 			if g.showItemNames || useNumbers {
 				if g.showItemNames || useNumbers {
-					fs := fontScale()
-					labels = append(labels, label{formatted, int(x) - int(float64(width)*fs/2), int(y) + 4, width, labelClr})
+					labels = append(labels, label{formatted, int(x), int(y) + 4, labelClr})
 				}
 			}
 		}
@@ -144,7 +140,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			y := math.Round((float64(poi.Y) * 2 * g.zoom) + g.camY)
 
 			name := displayPOI(poi.ID)
-			formatted, width := formatLabel(name)
+			formatted, _ := formatLabel(name)
 			dotClr := color.RGBA{}
 			if idx, ok := g.legendMap["p"+name]; ok && idx-1 < len(g.legendColors) {
 				dotClr = g.legendColors[idx-1]
@@ -175,10 +171,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					}
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["p"+name])
-						width = len(formatted)
 					}
-					fs := fontScale()
-					labels = append(labels, label{formatted, int(x) - int(float64(width)*fs/2), int(y+h/2) + 2, width, labelClr})
+					labels = append(labels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
 					continue
 				}
 			}
@@ -189,18 +183,15 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["p"+name])
-				width = len(formatted)
 			}
-			fs := fontScale()
-			labels = append(labels, label{formatted, int(x) - int(float64(width)*fs/2), int(y) + 4, width, labelClr})
+			labels = append(labels, label{formatted, int(x), int(y) + 4, labelClr})
 		}
 
 		for _, l := range labels {
-			x := l.x
 			if l.clr.A != 0 {
-				drawTextWithBGBorderScale(screen, l.text, x, l.y, l.clr, 1)
+				drawTextWithBGBorderScale(screen, l.text, l.x, l.y, l.clr, 1, true)
 			} else {
-				drawTextWithBGScale(screen, l.text, x, l.y, 1)
+				drawTextWithBGScale(screen, l.text, l.x, l.y, 1, true)
 			}
 		}
 
@@ -212,15 +203,12 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 			astName := fmt.Sprintf("Asteroid: %s", aName)
 
-			w, _ := textDimensions(astName)
-			x := g.width/2 - w/2
-			drawTextWithBGScale(screen, astName, x, 30, 1)
+			x := g.width / 2
+			drawTextWithBGScale(screen, astName, x, 30, 1, true)
 			ar := g.asteroidArrowRect()
 			drawDownArrow(screen, ar, g.showAstMenu)
 
-			w, _ = textDimensions(label)
-			x = g.width/2 - w/2
-			drawTextWithBGScale(screen, label, x, 10, 1)
+			drawTextWithBGScale(screen, label, x, 10, 1, true)
 		}
 
 		if g.showLegend {
@@ -327,7 +315,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				y := math.Round((float64(gy.Y) * 2 * g.zoom) + g.camY)
 
 				name := displayGeyser(gy.ID)
-				formatted, width := formatLabel(name)
+				formatted, _ := formatLabel(name)
 				dotClr := color.RGBA{255, 0, 0, 255}
 				labelClr := dotClr
 				if !useNumbers {
@@ -349,10 +337,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
 						if useNumbers {
 							formatted = strconv.Itoa(g.legendMap["g"+name])
-							width = len(formatted)
 						}
-						fs := fontScale()
-						highlightLabels = append(highlightLabels, label{formatted, int(x) - int(float64(width)*fs/2), int(y+h/2) + 2, width, labelClr})
+						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
 						continue
 					}
 				}
@@ -361,10 +347,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
 				if useNumbers {
 					formatted = strconv.Itoa(g.legendMap["g"+name])
-					width = len(formatted)
 				}
-				fs := fontScale()
-				highlightLabels = append(highlightLabels, label{formatted, int(x) - int(float64(width)*fs/2), int(y) + 4, width, labelClr})
+				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
 			}
 
 			for _, poi := range highlightPOIs {
@@ -372,7 +356,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				y := math.Round((float64(poi.Y) * 2 * g.zoom) + g.camY)
 
 				name := displayPOI(poi.ID)
-				formatted, width := formatLabel(name)
+				formatted, _ := formatLabel(name)
 				dotClr := color.RGBA{255, 0, 0, 255}
 				labelClr := dotClr
 				if !useNumbers {
@@ -394,10 +378,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
 						if useNumbers {
 							formatted = strconv.Itoa(g.legendMap["p"+name])
-							width = len(formatted)
 						}
-						fs := fontScale()
-						highlightLabels = append(highlightLabels, label{formatted, int(x) - int(float64(width)*fs/2), int(y+h/2) + 2, width, labelClr})
+						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
 						continue
 					}
 				}
@@ -406,19 +388,17 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				vector.StrokeRect(screen, float32(x-3), float32(y-1), 6, 6, 2, dotClr, false)
 				if useNumbers {
 					formatted = strconv.Itoa(g.legendMap["p"+name])
-					width = len(formatted)
 				}
-				fs := fontScale()
-				highlightLabels = append(highlightLabels, label{formatted, int(x) - int(float64(width)*fs/2), int(y) + 4, width, labelClr})
+				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
 			}
 
 		}
 		if len(highlightLabels) > 0 {
 			for _, l := range highlightLabels {
 				if l.clr.A != 0 {
-					drawTextWithBGBorderScale(screen, l.text, l.x, l.y, l.clr, 1)
+					drawTextWithBGBorderScale(screen, l.text, l.x, l.y, l.clr, 1, true)
 				} else {
-					drawTextWithBGScale(screen, l.text, l.x, l.y, 1)
+					drawTextWithBGScale(screen, l.text, l.x, l.y, 1, true)
 				}
 			}
 		}

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -25,7 +25,7 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		worldX := int(math.Round(((float64(cx) - g.camX) / g.zoom) / 2))
 		worldY := int(math.Round(((float64(cy) - g.camY) / g.zoom) / 2))
 		coords := fmt.Sprintf("X: %d Y: %d", worldX, worldY)
-		drawTextWithBGScale(screen, coords, 5, g.height-20, 1)
+		drawTextWithBGScale(screen, coords, 5, g.height-20, 1, false)
 	}
 
 	if g.showInfo {
@@ -57,7 +57,7 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 	if g.showHelp && !g.screenshotMode {
 		rect := g.helpMenuRect()
 		drawFrame(screen, rect)
-		drawTextScale(screen, helpMessage, rect.Min.X+2, rect.Min.Y+2, 1)
+		drawTextScale(screen, helpMessage, rect.Min.X+2, rect.Min.Y+2, 1, false)
 		cr := g.helpCloseRect()
 		drawCloseButton(screen, cr)
 	}

--- a/drawing.go
+++ b/drawing.go
@@ -8,36 +8,42 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
-func drawTextWithBG(dst *ebiten.Image, text string, x, y int) {
+func drawTextWithBG(dst *ebiten.Image, text string, x, y int, center bool) {
 	w, h := textDimensions(text)
+	if center {
+		x -= w / 2
+	}
 	vector.DrawFilledRect(dst, float32(x-2), float32(y-2), float32(w+4), float32(h+4), color.RGBA{0, 0, 0, 128}, false)
-	drawText(dst, text, x, y)
+	drawText(dst, text, x, y, false)
 }
 
 // drawTextWithBG draws text with a translucent background.
 // Previously this supported arbitrary scaling, but the UI no longer scales,
 // so this helper simply draws at the current font size.
-func drawTextWithBGScale(dst *ebiten.Image, text string, x, y int, _ float64) {
-	drawTextWithBG(dst, text, x, y)
+func drawTextWithBGScale(dst *ebiten.Image, text string, x, y int, _ float64, center bool) {
+	drawTextWithBG(dst, text, x, y, center)
 }
 
-func drawTextWithBGBorder(dst *ebiten.Image, text string, x, y int, border color.Color) {
+func drawTextWithBGBorder(dst *ebiten.Image, text string, x, y int, border color.Color, center bool) {
 	w, h := textDimensions(text)
+	if center {
+		x -= w / 2
+	}
 	bx := x - 2
 	by := y - 2
 	bw := w + 4
 	bh := h + 4
 	vector.DrawFilledRect(dst, float32(bx-1), float32(by-1), float32(bw+2), float32(bh+2), border, false)
 	vector.DrawFilledRect(dst, float32(bx), float32(by), float32(bw), float32(bh), color.RGBA{0, 0, 0, 128}, false)
-	drawText(dst, text, x, y)
+	drawText(dst, text, x, y, false)
 }
 
-func drawTextWithBGBorderScale(dst *ebiten.Image, text string, x, y int, border color.Color, _ float64) {
-	drawTextWithBGBorder(dst, text, x, y, border)
+func drawTextWithBGBorderScale(dst *ebiten.Image, text string, x, y int, border color.Color, _ float64, center bool) {
+	drawTextWithBGBorder(dst, text, x, y, border, center)
 }
 
-func drawTextScale(dst *ebiten.Image, text string, x, y int, _ float64) {
-	drawText(dst, text, x, y)
+func drawTextScale(dst *ebiten.Image, text string, x, y int, _ float64, center bool) {
+	drawText(dst, text, x, y, center)
 }
 
 func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image, x, y int) {
@@ -64,7 +70,7 @@ func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image,
 		opIcon.GeoM.Translate(4, float64(h-iconH)/2)
 		img.DrawImage(icon, opIcon)
 	}
-	drawText(img, text, iconW+gap+4, 4)
+	drawText(img, text, iconW+gap+4, 4, false)
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(x-4), float64(y-4))
 	dst.DrawImage(img, op)
@@ -91,7 +97,7 @@ func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x
 		opIcon.GeoM.Translate(0, float64(h-iconH)/2)
 		img.DrawImage(icon, opIcon)
 	}
-	drawText(img, text, iconW+gap, (h-txtH)/2)
+	drawText(img, text, iconW+gap, (h-txtH)/2, false)
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(x), float64(y))
 	dst.DrawImage(img, op)

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -100,11 +100,10 @@ type Game struct {
 }
 
 type label struct {
-	text  string
-	x     int
-	y     int
-	width int
-	clr   color.RGBA
+	text string
+	x    int
+	y    int
+	clr  color.RGBA
 }
 
 type touchPoint struct {
@@ -156,7 +155,7 @@ func (g *Game) drawTooltip(dst *ebiten.Image, text string, rect image.Rectangle,
 	if y < 0 {
 		y = rect.Max.Y + 4
 	}
-	drawTextWithBGScale(dst, text, x, y, scale)
+	drawTextWithBGScale(dst, text, x, y, scale, false)
 }
 
 func (g *Game) helpRect() image.Rectangle {

--- a/legend.go
+++ b/legend.go
@@ -38,7 +38,7 @@ func buildLegendImage(biomes []BiomePath) (*ebiten.Image, []string) {
 	img.Fill(color.RGBA{0, 0, 0, 77})
 
 	y := 10
-	drawTextWithBG(img, "Biomes", 5, y)
+	drawTextWithBG(img, "Biomes", 5, y, false)
 	y += spacing
 	for _, name := range names {
 		clr, ok := biomeColors[name]
@@ -46,11 +46,11 @@ func buildLegendImage(biomes []BiomePath) (*ebiten.Image, []string) {
 			clr = color.RGBA{60, 60, 60, 255}
 		}
 		vector.DrawFilledRect(img, 5, float32(y), 20, 10, clr, false)
-		drawTextWithBGBorder(img, displayBiome(name), 30, y, clr)
+		drawTextWithBGBorder(img, displayBiome(name), 30, y, clr, false)
 		y += spacing
 	}
 
-	drawTextWithBGBorder(img, "Clear", 5, y, buttonBorderColor)
+	drawTextWithBGBorder(img, "Clear", 5, y, buttonBorderColor, false)
 
 	return img, names
 }
@@ -105,17 +105,17 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 		img := ebiten.NewImage(width, height)
 		img.Fill(color.RGBA{0, 0, 0, 77})
 		y := 10
-		drawTextWithBG(img, "Items", 5, y)
+		drawTextWithBG(img, "Items", 5, y, false)
 		y += spacing
 		for i, e := range g.legendEntries {
 			clr := color.RGBA{}
 			if i < len(g.legendColors) {
 				clr = g.legendColors[i]
 			}
-			drawTextWithBGBorder(img, e, 5, y, clr)
+			drawTextWithBGBorder(img, e, 5, y, clr, false)
 			y += spacing
 		}
-		drawTextWithBGBorder(img, "Clear", 5, y, buttonBorderColor)
+		drawTextWithBGBorder(img, "Clear", 5, y, buttonBorderColor, false)
 		g.legendImage = img
 	}
 	w := float64(g.legendImage.Bounds().Dx())

--- a/options_menu.go
+++ b/options_menu.go
@@ -62,7 +62,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	w, h := g.optionsMenuSize()
 	img := ebiten.NewImage(w, h)
 	drawFrame(img, image.Rect(0, 0, w, h))
-	drawText(img, OptionsMenuTitle, 6, 6)
+	drawText(img, OptionsMenuTitle, 6, 6, false)
 	y := 6 + menuSpacing()
 
 	drawToggle := func(label string, enabled bool) {
@@ -72,7 +72,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 		if notoFont != nil {
 			lh = notoFont.Metrics().Height.Ceil()
 		}
-		drawText(img, label, btn.Min.X+6, btn.Min.Y+(menuButtonHeight()-lh)/2)
+		drawText(img, label, btn.Min.X+6, btn.Min.Y+(menuButtonHeight()-lh)/2, false)
 		y += menuSpacing()
 	}
 
@@ -81,7 +81,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Use Item Numbers", g.useNumbers)
 
 	label := "Font Size"
-	drawText(img, label, 6, y)
+	drawText(img, label, 6, y, false)
 	tw, _ := textDimensions(label)
 	bx := 6 + tw + 6
 	minus := image.Rect(bx, y-4, bx+20, y-4+menuButtonHeight())
@@ -93,7 +93,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	y += menuSpacing()
 
 	label = "Icon Size"
-	drawText(img, label, 6, y)
+	drawText(img, label, 6, y, false)
 	tw, _ = textDimensions(label)
 	bx = 6 + tw + 6
 	minus = image.Rect(bx, y-4, bx+20, y-4+menuButtonHeight())
@@ -110,15 +110,15 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Linear Filtering", g.linearFilter)
 
 	fps := fmt.Sprintf("FPS: %.1f", ebiten.ActualFPS())
-	drawText(img, fps, 6, y)
+	drawText(img, fps, 6, y, false)
 	y += menuSpacing()
 
-	drawText(img, "Version: "+ClientVersion, 6, y)
+	drawText(img, "Version: "+ClientVersion, 6, y, false)
 	y += menuSpacing()
 
 	btn := image.Rect(4, y-4, w-4, y-4+22)
 	drawButton(img, btn, true)
-	drawText(img, "Close", btn.Min.X+6, btn.Min.Y+4)
+	drawText(img, "Close", btn.Min.X+6, btn.Min.Y+4, false)
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -56,7 +56,7 @@ func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
 	w, h := g.screenshotMenuSize()
 	img := ebiten.NewImage(w, h)
 	drawFrame(img, image.Rect(0, 0, w, h))
-	drawText(img, ScreenshotMenuTitle, 6, 6)
+	drawText(img, ScreenshotMenuTitle, 6, 6, false)
 
 	label := ScreenshotSaveLabel
 	if g.ssPending > 0 {
@@ -88,7 +88,7 @@ func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
 		if notoFont != nil {
 			lh = notoFont.Metrics().Height.Ceil()
 		}
-		drawText(img, it, btn.Min.X+6, btn.Min.Y+(menuButtonHeight()-lh)/2)
+		drawText(img, it, btn.Min.X+6, btn.Min.Y+(menuButtonHeight()-lh)/2, false)
 		y += menuSpacing()
 		if i == len(ScreenshotQualities)-1 || i == len(ScreenshotQualities) {
 			y += menuSpacing()

--- a/text_draw.go
+++ b/text_draw.go
@@ -9,16 +9,24 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/text"
 )
 
-func drawText(dst *ebiten.Image, str string, x, y int) {
+func drawText(dst *ebiten.Image, str string, x, y int, center bool) {
 	if notoFont == nil {
 		return
+	}
+	if center {
+		w, _ := textDimensions(str)
+		x -= w / 2
 	}
 	text.Draw(dst, str, notoFont, x, y+int(notoFont.Metrics().Ascent.Ceil()), color.White)
 }
 
-func drawTextColor(dst *ebiten.Image, str string, x, y int, clr color.Color) {
+func drawTextColor(dst *ebiten.Image, str string, x, y int, center bool, clr color.Color) {
 	if notoFont == nil {
 		return
+	}
+	if center {
+		w, _ := textDimensions(str)
+		x -= w / 2
 	}
 	text.Draw(dst, str, notoFont, x, y+int(notoFont.Metrics().Ascent.Ceil()), clr)
 }

--- a/text_stub.go
+++ b/text_stub.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Stubbed text helpers for tests. They avoid drawing but keep signatures.
-func drawText(dst *ebiten.Image, str string, x, y int) {}
+func drawText(dst *ebiten.Image, str string, x, y int, center bool) {}
 
-func drawTextColor(dst *ebiten.Image, str string, x, y int, clr color.Color) {}
+func drawTextColor(dst *ebiten.Image, str string, x, y int, center bool, clr color.Color) {}
 
 func textDimensions(str string) (int, int) {
 	lines := strings.Split(str, "\n")

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -147,13 +147,13 @@ func (g *Game) drawLoadingScreen(dst *ebiten.Image) bool {
 		msg = "Fetching asteroid data..."
 		scale = 2.0
 	}
-	w, h := textDimensions(msg)
-	x := g.width/2 - int(float64(w)*scale/2)
+	_, h := textDimensions(msg)
+	x := g.width / 2
 	y := g.height/2 - int(float64(h)*scale/2)
 	if g.statusError {
-		drawTextWithBGBorderScale(dst, msg, x, y, errorBorderColor, scale)
+		drawTextWithBGBorderScale(dst, msg, x, y, errorBorderColor, scale, true)
 	} else {
-		drawTextWithBGScale(dst, msg, x, y, scale)
+		drawTextWithBGScale(dst, msg, x, y, scale, true)
 	}
 	g.lastDraw = time.Now()
 	return true


### PR DESCRIPTION
## Summary
- allow centering text directly in draw helpers
- drop unused width from label struct
- use the centering option for world item labels and status messages
- update menus and helpers for new text-drawing API

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686acaccd664832a8e53021b8829758e