### PR TITLE
Fix menu layout for font size

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -19,8 +19,9 @@ func (g *Game) asteroidArrowRect() image.Rectangle {
 	text := "Asteroid: " + name
 	w, _ := textDimensions(text)
 	x := g.width/2 + w/2 + 4
-	size := 12
-	y := 30 + 8 - size/2
+	size := int(float64(12) * fontScale())
+	baseline := seedBaseline() + notoFont.Metrics().Height.Ceil() + 4
+	y := baseline + notoFont.Metrics().Descent.Ceil() + 4 - size/2
 	return image.Rect(x, y, x+size, y+size)
 }
 
@@ -33,7 +34,7 @@ func (g *Game) asteroidInfoRect() image.Rectangle {
 	}
 	sw, sh := textDimensions(g.coord)
 	sx := g.width/2 - sw/2
-	seedRect := image.Rect(sx-2, 8, sx+sw+2, 8+sh+4)
+	seedRect := image.Rect(sx-2, seedBaseline()-2, sx+sw+2, seedBaseline()-2+sh+4)
 
 	name := g.asteroidID
 	if name == "" {
@@ -42,7 +43,8 @@ func (g *Game) asteroidInfoRect() image.Rectangle {
 	astText := "Asteroid: " + name
 	aw, ah := textDimensions(astText)
 	ax := g.width/2 - aw/2
-	astRect := image.Rect(ax-2, 28, ax+aw+2, 28+ah+4)
+	astBase := seedBaseline() + notoFont.Metrics().Height.Ceil() + 4
+	astRect := image.Rect(ax-2, astBase-2, ax+aw+2, astBase-2+ah+4)
 
 	rect := seedRect.Union(astRect)
 	rect = rect.Union(g.asteroidArrowRect())

--- a/draw.go
+++ b/draw.go
@@ -204,11 +204,11 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			astName := fmt.Sprintf("Asteroid: %s", aName)
 
 			x := g.width / 2
-			drawTextWithBGScale(screen, astName, x, 30, 1, true)
+			astBase := seedBaseline() + notoFont.Metrics().Height.Ceil() + 4
+			drawTextWithBGScale(screen, astName, x, astBase, 1, true)
 			ar := g.asteroidArrowRect()
 			drawDownArrow(screen, ar, g.showAstMenu)
-
-			drawTextWithBGScale(screen, label, x, 10, 1, true)
+			drawTextWithBGScale(screen, label, x, seedBaseline(), 1, true)
 		}
 
 		if g.showLegend {

--- a/fonts.go
+++ b/fonts.go
@@ -84,6 +84,10 @@ func menuSpacing() int {
 	return int(float64(26) * fontScale())
 }
 
+func seedBaseline() int {
+	return 10
+}
+
 func init() {
 	setFontSize(fontSize)
 }

--- a/options_menu.go
+++ b/options_menu.go
@@ -116,9 +116,13 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawText(img, "Version: "+ClientVersion, 6, y, false)
 	y += menuSpacing()
 
-	btn := image.Rect(4, y-4, w-4, y-4+22)
+	btn := image.Rect(4, y-4, w-4, y-4+menuButtonHeight())
 	drawButton(img, btn, true)
-	drawText(img, "Close", btn.Min.X+6, btn.Min.Y+4, false)
+	lh := menuButtonHeight() - 5
+	if notoFont != nil {
+		lh = notoFont.Metrics().Height.Ceil()
+	}
+	drawText(img, "Close", btn.Min.X+6, btn.Min.Y+(menuButtonHeight()-lh)/2, false)
 
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Translate(float64(rect.Min.X), float64(rect.Min.Y))


### PR DESCRIPTION
## Summary
- scale Close button in options menu to match font size
- adjust seed/asteroid text spacing so it scales with font size
- expose a helper to compute the seed text baseline

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ad0d24b7c832a883dde02d9f75a56