### PR TITLE
Update dev guide and dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,8 @@ This repository contains a small ebiten viewer written in Go.
   ```
 - Image assets are committed to the repo and embedded at build time, so no
   download step is required.
-- Run `./install_deps.sh` once to install the required build tools such as Go,
-  Xvfb and the `webp` utilities. The script can be run again to pick up updated
-  dependencies.
-- If you install any packages while working in this environment, add them to
+- Run `./install_deps.sh` and related scripts **only** when you need the packages they install. These helpers speed up environment setup when you require tools like Go, Xvfb or the `webp` utilities.
+- If you install additional packages while working, add them to
   `scripts/install_deps.sh` so they are included in the setup process.
 
 Additional tasks to keep the project healthy:

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 
 sudo apt-get update
 sudo apt-get install -y git curl build-essential pkg-config \
-    libasound2-dev libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
+    libasound2-dev libx11-dev libxft-dev x11proto-dev \
+    libxext-dev libxrandr-dev libxinerama-dev \
     libxcursor-dev libxi-dev libxrender-dev libxxf86vm-dev \
     libgl1-mesa-dev libgl1 xorg-dev xvfb webp binaryen brotli
 


### PR DESCRIPTION
## Summary
- clarify how `install_deps.sh` should be used in `AGENTS.md`
- add missing X11 development headers to the install script

## Testing
- `./scripts/install_deps.sh`
- `go test -tags test ./...` *(fails: build failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ad27b30d4832a99e4a63521fa7479