### PR TITLE
Update screenshot font and show-item toggles

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -47,7 +47,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		labels := []label{}
 		var highlightGeysers []Geyser
 		var highlightPOIs []PointOfInterest
-		useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+		useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 		if g.legendMap == nil {
 			g.initObjectLegend()
 		}
@@ -309,90 +309,88 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 
 		highlightLabels := []label{}
-		if g.showItemNames {
-			for _, gy := range highlightGeysers {
-				x := math.Round((float64(gy.X) * 2 * g.zoom) + g.camX)
-				y := math.Round((float64(gy.Y) * 2 * g.zoom) + g.camY)
+		for _, gy := range highlightGeysers {
+			x := math.Round((float64(gy.X) * 2 * g.zoom) + g.camX)
+			y := math.Round((float64(gy.Y) * 2 * g.zoom) + g.camY)
 
-				name := displayGeyser(gy.ID)
-				formatted, _ := formatLabel(name)
-				dotClr := color.RGBA{255, 0, 0, 255}
-				labelClr := dotClr
-				if !useNumbers {
-					labelClr = color.RGBA{}
-				}
-
-				if iconName := iconForGeyser(gy.ID); iconName != "" {
-					if img, ok := g.icons[iconName]; ok && img != nil {
-						op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
-						maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
-						scale := g.zoom * IconScale * g.iconScale * float64(BaseIconPixels) / maxDim
-						op.GeoM.Scale(scale, scale)
-						w := float64(img.Bounds().Dx()) * scale
-						h := float64(img.Bounds().Dy()) * scale
-						left := math.Round(x - w/2)
-						top := math.Round(y - h/2)
-						op.GeoM.Translate(left, top)
-						screen.DrawImage(img, op)
-						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
-						if useNumbers {
-							formatted = strconv.Itoa(g.legendMap["g"+name])
-						}
-						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
-						continue
-					}
-				}
-
-				vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
-				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
-				if useNumbers {
-					formatted = strconv.Itoa(g.legendMap["g"+name])
-				}
-				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+			name := displayGeyser(gy.ID)
+			formatted, _ := formatLabel(name)
+			dotClr := color.RGBA{255, 0, 0, 255}
+			labelClr := dotClr
+			if !useNumbers {
+				labelClr = color.RGBA{}
 			}
 
-			for _, poi := range highlightPOIs {
-				x := math.Round((float64(poi.X) * 2 * g.zoom) + g.camX)
-				y := math.Round((float64(poi.Y) * 2 * g.zoom) + g.camY)
-
-				name := displayPOI(poi.ID)
-				formatted, _ := formatLabel(name)
-				dotClr := color.RGBA{255, 0, 0, 255}
-				labelClr := dotClr
-				if !useNumbers {
-					labelClr = color.RGBA{}
-				}
-
-				if iconName := iconForPOI(poi.ID); iconName != "" {
-					if img, ok := g.icons[iconName]; ok && img != nil {
-						op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
-						maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
-						scale := g.zoom * IconScale * g.iconScale * float64(BaseIconPixels) / maxDim
-						op.GeoM.Scale(scale, scale)
-						w := float64(img.Bounds().Dx()) * scale
-						h := float64(img.Bounds().Dy()) * scale
-						left := math.Round(x - w/2)
-						top := math.Round(y - h/2)
-						op.GeoM.Translate(left, top)
-						screen.DrawImage(img, op)
-						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
-						if useNumbers {
-							formatted = strconv.Itoa(g.legendMap["p"+name])
-						}
-						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
-						continue
+			if iconName := iconForGeyser(gy.ID); iconName != "" {
+				if img, ok := g.icons[iconName]; ok && img != nil {
+					op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
+					maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+					scale := g.zoom * IconScale * g.iconScale * float64(BaseIconPixels) / maxDim
+					op.GeoM.Scale(scale, scale)
+					w := float64(img.Bounds().Dx()) * scale
+					h := float64(img.Bounds().Dy()) * scale
+					left := math.Round(x - w/2)
+					top := math.Round(y - h/2)
+					op.GeoM.Translate(left, top)
+					screen.DrawImage(img, op)
+					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
+					if useNumbers {
+						formatted = strconv.Itoa(g.legendMap["g"+name])
 					}
+					highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					continue
 				}
-
-				vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
-				vector.StrokeRect(screen, float32(x-3), float32(y-1), 6, 6, 2, dotClr, false)
-				if useNumbers {
-					formatted = strconv.Itoa(g.legendMap["p"+name])
-				}
-				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
 			}
 
+			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
+			vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
+			if useNumbers {
+				formatted = strconv.Itoa(g.legendMap["g"+name])
+			}
+			highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
 		}
+
+		for _, poi := range highlightPOIs {
+			x := math.Round((float64(poi.X) * 2 * g.zoom) + g.camX)
+			y := math.Round((float64(poi.Y) * 2 * g.zoom) + g.camY)
+
+			name := displayPOI(poi.ID)
+			formatted, _ := formatLabel(name)
+			dotClr := color.RGBA{255, 0, 0, 255}
+			labelClr := dotClr
+			if !useNumbers {
+				labelClr = color.RGBA{}
+			}
+
+			if iconName := iconForPOI(poi.ID); iconName != "" {
+				if img, ok := g.icons[iconName]; ok && img != nil {
+					op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
+					maxDim := math.Max(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))
+					scale := g.zoom * IconScale * g.iconScale * float64(BaseIconPixels) / maxDim
+					op.GeoM.Scale(scale, scale)
+					w := float64(img.Bounds().Dx()) * scale
+					h := float64(img.Bounds().Dy()) * scale
+					left := math.Round(x - w/2)
+					top := math.Round(y - h/2)
+					op.GeoM.Translate(left, top)
+					screen.DrawImage(img, op)
+					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
+					if useNumbers {
+						formatted = strconv.Itoa(g.legendMap["p"+name])
+					}
+					highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					continue
+				}
+			}
+
+			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
+			vector.StrokeRect(screen, float32(x-3), float32(y-1), 6, 6, 2, dotClr, false)
+			if useNumbers {
+				formatted = strconv.Itoa(g.legendMap["p"+name])
+			}
+			highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+		}
+
 		if len(highlightLabels) > 0 {
 			for _, l := range highlightLabels {
 				if l.clr.A != 0 {

--- a/fonts.go
+++ b/fonts.go
@@ -14,7 +14,7 @@ var notoTTF []byte
 
 const (
 	baseFontSize       = 12.0
-	screenshotFontSize = 14.0
+	screenshotFontSize = 18.0
 )
 
 var (

--- a/legend.go
+++ b/legend.go
@@ -274,7 +274,7 @@ func (g *Game) maxItemScroll() float64 {
 }
 
 func (g *Game) itemPanelVisible() bool {
-	return g.showLegend && g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	return g.showLegend && g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 }
 
 func (g *Game) updateHover(mx, my int) {
@@ -309,7 +309,7 @@ func (g *Game) updateHover(mx, my int) {
 			}
 		}
 	}
-	useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 	if useNumbers && g.legendImage != nil {
 		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12
@@ -388,7 +388,7 @@ func (g *Game) clickLegend(mx, my int) bool {
 			}
 		}
 	}
-	useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 	if useNumbers && g.legendImage != nil {
 		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12

--- a/touch_input.go
+++ b/touch_input.go
@@ -42,7 +42,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 						g.touchUI = true
 					}
 				}
-				useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+				useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 				if !g.touchUI && useNumbers && g.legendImage != nil {
 					lw := g.legendImage.Bounds().Dx()
 					x0 := g.width - lw - 12
@@ -80,7 +80,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 							g.updateHover(x, y)
 						}
 					}
-					useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if useNumbers && g.legendImage != nil {
 						lw := g.legendImage.Bounds().Dx()
 						x0 := g.width - lw - 12
@@ -124,7 +124,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 							g.touchUI = true
 						}
 					}
-					useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if !g.touchUI && useNumbers && g.legendImage != nil {
 						lw := g.legendImage.Bounds().Dx()
 						x0 := g.width - lw - 12

--- a/update.go
+++ b/update.go
@@ -91,7 +91,7 @@ func (g *Game) Update() error {
 			g.adjustGeyserScroll(-float64(wheelY) * 10)
 		} else {
 			handled := false
-			useNumbers := g.useNumbers && g.showItemNames && g.zoom < LegendZoomThreshold && !g.screenshotMode
+			useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 			if g.legend != nil {
 				lw := g.legend.Bounds().Dx()
 				lh := g.legend.Bounds().Dy()


### PR DESCRIPTION
## Summary
- enlarge screenshot font to 18pt
- decouple item number rendering from Show Item Names
- keep highlight drawing when names are hidden

## Testing
- `go fmt` on all go files
- `go test -tags test ./...` *(fails: missing X11 headers during build)*

------
https://chatgpt.com/codex/tasks/task_e_686ad1f6e5cc832ab5adfe97e977fbf8