### PR TITLE
Refactor duplicate color values

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -86,8 +86,8 @@ func drawCheck(dst *ebiten.Image, rect image.Rectangle) {
 	y1 := float32(rect.Min.Y) + float32(rect.Dy())*0.8
 	x2 := float32(rect.Min.X) + float32(rect.Dx())*0.8
 	y2 := float32(rect.Min.Y) + float32(rect.Dy())*0.2
-	vector.StrokeLine(dst, x0, y0, x1, y1, thickness, colorWhite, true)
-	vector.StrokeLine(dst, x1, y1, x2, y2, thickness, colorWhite, true)
+	vector.StrokeLine(dst, x0, y0, x1, y1, thickness, color.White, true)
+	vector.StrokeLine(dst, x1, y1, x2, y2, thickness, color.White, true)
 }
 
 func (g *Game) asteroidMenuSize() (int, int) {
@@ -245,5 +245,3 @@ func (g *Game) centerAndFit() {
 	g.camY = (float64(g.height) - float64(g.astHeight)*2*g.zoom) / 2
 	g.clampCamera()
 }
-
-var colorWhite = color.RGBA{255, 255, 255, 255}

--- a/const.go
+++ b/const.go
@@ -101,7 +101,11 @@ var biomeOrder = []string{
 var (
 	buttonActiveColor   = color.RGBA{0, 96, 96, 255}
 	buttonInactiveColor = color.RGBA{40, 40, 40, 255}
-	buttonBorderColor   = color.RGBA{255, 255, 255, 255}
+	buttonBorderColor   = color.White
 	frameColor          = color.RGBA{0, 0, 0, 192}
-	bottomTrayColor     = color.RGBA{0, 0, 0, 192}
+	bottomTrayColor     = frameColor
+	highlightColor      = color.RGBA{255, 0, 0, 255}
+	legendBGColor       = color.RGBA{0, 0, 0, 77}
+	overlayColor        = color.RGBA{0, 0, 0, 180}
+	backgroundColor     = color.RGBA{30, 30, 30, 255}
 )

--- a/draw.go
+++ b/draw.go
@@ -20,7 +20,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		return
 	}
 	if g.needsRedraw {
-		screen.Fill(color.RGBA{30, 30, 30, 255})
+		screen.Fill(backgroundColor)
 		if g.textures && g.biomeTextures != nil {
 			if tex := g.biomeTextures["Space"]; tex != nil {
 				clr := color.RGBA{255, 255, 255, 255}
@@ -223,7 +223,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				y0 := math.Round((10 + spacing + spacing*float64(g.selectedBiome)) - g.biomeScroll)
 				h := math.Round(spacing)
 				w := math.Round(float64(g.legend.Bounds().Dx()))
-				vector.StrokeRect(screen, 0.5, float32(y0)-4, float32(w)-1, float32(h)-1, 2, color.RGBA{255, 0, 0, 255}, false)
+				vector.StrokeRect(screen, 0.5, float32(y0)-4, float32(w)-1, float32(h)-1, 2, highlightColor, false)
 			}
 			if useNumbers && !g.screenshotMode {
 				g.drawNumberLegend(screen)
@@ -237,7 +237,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			sr := g.screenshotRect()
 			scx := float32(sr.Min.X + size/2)
 			scy := float32(sr.Min.Y + size/2)
-			vector.DrawFilledCircle(screen, scx, scy, float32(size)/2, color.RGBA{0, 0, 0, 180}, true)
+			vector.DrawFilledCircle(screen, scx, scy, float32(size)/2, overlayColor, true)
 			if cam, ok := g.icons["../icons/camera.png"]; ok && cam != nil {
 				op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 				scale := float64(size) / math.Max(float64(cam.Bounds().Dx()), float64(cam.Bounds().Dy()))
@@ -252,7 +252,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			hr := g.helpRect()
 			cx := float32(hr.Min.X + size/2)
 			cy := float32(hr.Min.Y + size/2)
-			vector.DrawFilledCircle(screen, cx, cy, float32(size)/2, color.RGBA{0, 0, 0, 180}, true)
+			vector.DrawFilledCircle(screen, cx, cy, float32(size)/2, overlayColor, true)
 			if helpImg, ok := g.icons["../icons/help.png"]; ok && helpImg != nil {
 				op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 				sc := float64(size) / math.Max(float64(helpImg.Bounds().Dx()), float64(helpImg.Bounds().Dy()))
@@ -267,7 +267,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			or := g.optionsRect()
 			ocx := float32(or.Min.X + size/2)
 			ocy := float32(or.Min.Y + size/2)
-			vector.DrawFilledCircle(screen, ocx, ocy, float32(size)/2, color.RGBA{0, 0, 0, 180}, true)
+			vector.DrawFilledCircle(screen, ocx, ocy, float32(size)/2, overlayColor, true)
 			if gear, ok := g.icons["../icons/gear.png"]; ok && gear != nil {
 				op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 				sc := float64(size) / math.Max(float64(gear.Bounds().Dx()), float64(gear.Bounds().Dy()))
@@ -282,7 +282,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			gr := g.geyserRect()
 			gcx := float32(gr.Min.X + size/2)
 			gcy := float32(gr.Min.Y + size/2)
-			vector.DrawFilledCircle(screen, gcx, gcy, float32(size)/2, color.RGBA{0, 0, 0, 180}, true)
+			vector.DrawFilledCircle(screen, gcx, gcy, float32(size)/2, overlayColor, true)
 			if icon, ok := g.icons["geyser_water.png"]; ok && icon != nil {
 				op := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 				sc := float64(size) / math.Max(float64(icon.Bounds().Dx()), float64(icon.Bounds().Dy()))
@@ -316,7 +316,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 				name := displayGeyser(gy.ID)
 				formatted, _ := formatLabel(name)
-				dotClr := color.RGBA{255, 0, 0, 255}
+				dotClr := highlightColor
 				labelClr := dotClr
 				if !useNumbers {
 					labelClr = color.RGBA{}
@@ -357,7 +357,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 				name := displayPOI(poi.ID)
 				formatted, _ := formatLabel(name)
-				dotClr := color.RGBA{255, 0, 0, 255}
+				dotClr := highlightColor
 				labelClr := dotClr
 				if !useNumbers {
 					labelClr = color.RGBA{}

--- a/legend.go
+++ b/legend.go
@@ -35,7 +35,7 @@ func buildLegendImage(biomes []BiomePath) (*ebiten.Image, []string) {
 	height := spacing*(len(names)+2) + 7
 
 	img := ebiten.NewImage(width, height)
-	img.Fill(color.RGBA{0, 0, 0, 77})
+	img.Fill(legendBGColor)
 
 	y := 10
 	drawTextWithBG(img, "Biomes", 5, y, false)
@@ -103,7 +103,7 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 		width := maxW + 10
 		height := spacing*(len(g.legendEntries)+2) + 7
 		img := ebiten.NewImage(width, height)
-		img.Fill(color.RGBA{0, 0, 0, 77})
+		img.Fill(legendBGColor)
 		y := 10
 		drawTextWithBG(img, "Items", 5, y, false)
 		y += spacing
@@ -128,7 +128,7 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 		spacing := float64(rowSpacing())
 		hy := y + (10 + spacing*float64(g.selectedItem+1))
 		hh := spacing
-		vector.StrokeRect(dst, float32(math.Round(x))+0.5, float32(math.Round(hy))-4, float32(math.Round(w))-1, float32(math.Round(hh))-1, 2, color.RGBA{255, 0, 0, 255}, false)
+		vector.StrokeRect(dst, float32(math.Round(x))+0.5, float32(math.Round(hy))-4, float32(math.Round(w))-1, float32(math.Round(hh))-1, 2, highlightColor, false)
 	}
 }
 

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"golang.org/x/image/bmp"
 	"image"
-	"image/color"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -191,8 +190,4 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	g.showShotMenu = menu
 	g.needsRedraw = true
 	return rgba
-}
-
-func colorRGBA(r, g0, b, a uint8) color.RGBA {
-	return color.RGBA{R: r, G: g0, B: b, A: a}
 }

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -140,7 +140,7 @@ func (g *Game) drawLoadingScreen(dst *ebiten.Image) bool {
 	if !(g.loading || (len(g.biomes) == 0 && g.status != "")) {
 		return false
 	}
-	dst.Fill(color.RGBA{30, 30, 30, 255})
+	dst.Fill(backgroundColor)
 	msg := g.status
 	scale := 1.0
 	if msg == "" {


### PR DESCRIPTION
## Summary
- consolidate common colors into shared constants
- remove unused helper from screenshot menu
- use the new constants across drawing code
- drop unneeded color helper in asteroid menu

## Testing
- `go test ./...`
- `go test -tags test ./...` *(fails: undefined methods)*

------
https://chatgpt.com/codex/tasks/task_e_686ad22239a0832a93d886d0a8aa3139