### PR TITLE
Fix UI text clipping and item name toggle

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -47,7 +47,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		labels := []label{}
 		var highlightGeysers []Geyser
 		var highlightPOIs []PointOfInterest
-		useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
+		useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && g.showItemNames
 		if g.legendMap == nil {
 			g.initObjectLegend()
 		}
@@ -195,7 +195,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 		}
 
-		if g.coord != "" && !g.screenshotMode {
+		if g.coord != "" && !g.screenshotMode && g.showItemNames {
 			label := g.coord
 			aName := g.asteroidID
 			if aName == "" {
@@ -313,13 +313,13 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			x := math.Round((float64(gy.X) * 2 * g.zoom) + g.camX)
 			y := math.Round((float64(gy.Y) * 2 * g.zoom) + g.camY)
 
-				name := displayGeyser(gy.ID)
-				formatted, _ := formatLabel(name)
-				dotClr := highlightColor
-				labelClr := dotClr
-				if !useNumbers {
-					labelClr = color.RGBA{}
-				}
+			name := displayGeyser(gy.ID)
+			formatted, _ := formatLabel(name)
+			dotClr := highlightColor
+			labelClr := dotClr
+			if !useNumbers {
+				labelClr = color.RGBA{}
+			}
 
 			if iconName := iconForGeyser(gy.ID); iconName != "" {
 				if img, ok := g.icons[iconName]; ok && img != nil {
@@ -337,7 +337,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["g"+name])
 					}
-					highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					if g.showItemNames {
+						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					}
 					continue
 				}
 			}
@@ -347,20 +349,22 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["g"+name])
 			}
-			highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+			if g.showItemNames {
+				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+			}
 		}
 
 		for _, poi := range highlightPOIs {
 			x := math.Round((float64(poi.X) * 2 * g.zoom) + g.camX)
 			y := math.Round((float64(poi.Y) * 2 * g.zoom) + g.camY)
 
-				name := displayPOI(poi.ID)
-				formatted, _ := formatLabel(name)
-				dotClr := highlightColor
-				labelClr := dotClr
-				if !useNumbers {
-					labelClr = color.RGBA{}
-				}
+			name := displayPOI(poi.ID)
+			formatted, _ := formatLabel(name)
+			dotClr := highlightColor
+			labelClr := dotClr
+			if !useNumbers {
+				labelClr = color.RGBA{}
+			}
 
 			if iconName := iconForPOI(poi.ID); iconName != "" {
 				if img, ok := g.icons[iconName]; ok && img != nil {
@@ -378,7 +382,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["p"+name])
 					}
-					highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					if g.showItemNames {
+						highlightLabels = append(highlightLabels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					}
 					continue
 				}
 			}
@@ -388,7 +394,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["p"+name])
 			}
-			highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+			if g.showItemNames {
+				highlightLabels = append(highlightLabels, label{formatted, int(x), int(y) + 4, labelClr})
+			}
 		}
 
 		if len(highlightLabels) > 0 {

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -22,10 +22,14 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		crossClr := color.RGBA{255, 255, 255, 30}
 		vector.StrokeLine(screen, float32(cx-CrosshairSize), float32(cy), float32(cx+CrosshairSize), float32(cy), 1, crossClr, true)
 		vector.StrokeLine(screen, float32(cx), float32(cy-CrosshairSize), float32(cx), float32(cy+CrosshairSize), 1, crossClr, true)
-		worldX := int(math.Round(((float64(cx) - g.camX) / g.zoom) / 2))
-		worldY := int(math.Round(((float64(cy) - g.camY) / g.zoom) / 2))
-		coords := fmt.Sprintf("X: %d Y: %d", worldX, worldY)
-		drawTextWithBGScale(screen, coords, 5, g.height-20, 1, false)
+		if g.showItemNames {
+			worldX := int(math.Round(((float64(cx) - g.camX) / g.zoom) / 2))
+			worldY := int(math.Round(((float64(cy) - g.camY) / g.zoom) / 2))
+			coords := fmt.Sprintf("X: %d Y: %d", worldX, worldY)
+			lh := notoFont.Metrics().Height.Ceil()
+			y := g.height - lh - 8
+			drawTextWithBGScale(screen, coords, 5, y, 1, false)
+		}
 	}
 
 	if g.showInfo {

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -47,6 +47,9 @@ func (g *Game) screenshotMenuRect() image.Rectangle {
 	if y < 0 {
 		y = 0
 	}
+	if y+h > g.height {
+		y = g.height - h
+	}
 	return image.Rect(x, y, x+w, y+h)
 }
 


### PR DESCRIPTION
## Summary
- ensure coordinate text stays onscreen when font size changes
- keep screenshot menu inside the window
- hide all world text when item names are disabled

## Testing
- `gofmt -w *.go`
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ad6872710832abcde39407744a4c0