### PR TITLE
Fix POI labels obey Show Item Names

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -172,7 +172,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["p"+name])
 					}
-					labels = append(labels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					if g.showItemNames || useNumbers {
+						labels = append(labels, label{formatted, int(x), int(y+h/2) + 2, labelClr})
+					}
 					continue
 				}
 			}
@@ -184,7 +186,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["p"+name])
 			}
-			labels = append(labels, label{formatted, int(x), int(y) + 4, labelClr})
+			if g.showItemNames || useNumbers {
+				labels = append(labels, label{formatted, int(x), int(y) + 4, labelClr})
+			}
 		}
 
 		for _, l := range labels {


### PR DESCRIPTION
## Summary
- disable POI labels unless `Show Item Names` or `Use Item Numbers` are enabled

## Testing
- `go test -tags test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_686ad869e318832a9076400a074d19c0