### PR TITLE
Show font size in options menu

### DIFF
--- a/options_menu.go
+++ b/options_menu.go
@@ -17,12 +17,13 @@ func (g *Game) optionsRect() image.Rectangle {
 }
 
 func (g *Game) optionsMenuSize() (int, int) {
+	fontLabel := fmt.Sprintf("Font Size [-] [+] %.0fpt", fontSize)
 	labels := []string{
 		OptionsMenuTitle,
 		"Show Item Names",
 		"Show Legends",
 		"Use Item Numbers",
-		"Font Size [-] [+]",
+		fontLabel,
 		"Icon Size [-] [+]",
 		"Textures",
 		"Vsync",
@@ -90,6 +91,8 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawPlusMinus(img, minus, true)
 	drawButton(img, plus, false)
 	drawPlusMinus(img, plus, false)
+	sizeStr := fmt.Sprintf("%.0fpt", fontSize)
+	drawText(img, sizeStr, plus.Max.X+6, y, false)
 	y += menuSpacing()
 
 	label = "Icon Size"


### PR DESCRIPTION
## Summary
- display current font size in options menu
- adjust options menu width to account for value
- keep step size of 2pt for font adjustments

## Testing
- `go test -tags test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ada18180c832a8c1b6917129e9d4a