### PR TITLE
Fix legend touch area

### DIFF
--- a/game_helpers.go
+++ b/game_helpers.go
@@ -215,6 +215,27 @@ func (g *Game) bottomTrayRect() image.Rectangle {
 	return image.Rect(r.Min.X-4, r.Min.Y-4, r.Max.X+4, r.Max.Y+4)
 }
 
+func (g *Game) biomeLegendRect() image.Rectangle {
+	if g.legend == nil {
+		return image.Rectangle{}
+	}
+	w := g.legend.Bounds().Dx()
+	h := g.legend.Bounds().Dy()
+	y := -int(g.biomeScroll)
+	return image.Rect(0, y, w, y+h)
+}
+
+func (g *Game) itemLegendRect() image.Rectangle {
+	if g.legendImage == nil {
+		return image.Rectangle{}
+	}
+	w := g.legendImage.Bounds().Dx()
+	h := g.legendImage.Bounds().Dy()
+	x := g.width - w - 12
+	y := 10 - int(g.itemScroll)
+	return image.Rect(x, y, x+w, y+h)
+}
+
 func (g *Game) clampCamera() {
 	if g.astWidth == 0 || g.astHeight == 0 {
 		return

--- a/touch_input.go
+++ b/touch_input.go
@@ -37,16 +37,13 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 				g.touchUI = true
 			} else {
 				if g.legend != nil && g.showLegend {
-					lw := g.legend.Bounds().Dx()
-					if x >= 0 && x < lw {
+					if g.biomeLegendRect().Overlaps(pt) {
 						g.touchUI = true
 					}
 				}
 				useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 				if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
-					lw := g.legendImage.Bounds().Dx()
-					x0 := g.width - lw - 12
-					if x >= x0 && x < x0+lw {
+					if g.itemLegendRect().Overlaps(pt) {
 						g.touchUI = true
 					}
 				}
@@ -68,8 +65,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					g.adjustGeyserScroll(-float64(dy))
 				} else {
 					if g.legend != nil && g.showLegend {
-						lw := g.legend.Bounds().Dx()
-						if g.touchStartX >= 0 && g.touchStartX < lw {
+						pt := image.Rect(g.touchStartX, g.touchStartY, g.touchStartX+1, g.touchStartY+1)
+						if g.biomeLegendRect().Overlaps(pt) {
 							g.biomeScroll -= float64(dy)
 							if g.biomeScroll < 0 {
 								g.biomeScroll = 0
@@ -82,9 +79,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					}
 					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if useNumbers && g.legendImage != nil && g.showLegend {
-						lw := g.legendImage.Bounds().Dx()
-						x0 := g.width - lw - 12
-						if g.touchStartX >= x0 && g.touchStartX < x0+lw {
+						pt := image.Rect(g.touchStartX, g.touchStartY, g.touchStartX+1, g.touchStartY+1)
+						if g.itemLegendRect().Overlaps(pt) {
 							g.itemScroll -= float64(dy)
 							if g.itemScroll < 0 {
 								g.itemScroll = 0
@@ -119,16 +115,15 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					g.touchUI = true
 				} else {
 					if g.legend != nil && g.showLegend {
-						lw := g.legend.Bounds().Dx()
-						if x >= 0 && x < lw {
+						pt := image.Rect(x, y, x+1, y+1)
+						if g.biomeLegendRect().Overlaps(pt) {
 							g.touchUI = true
 						}
 					}
 					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
 					if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
-						lw := g.legendImage.Bounds().Dx()
-						x0 := g.width - lw - 12
-						if x >= x0 && x < x0+lw {
+						pt := image.Rect(x, y, x+1, y+1)
+						if g.itemLegendRect().Overlaps(pt) {
 							g.touchUI = true
 						}
 					}


### PR DESCRIPTION
## Summary
- add helper functions to compute legend rectangles
- restrict touch input handling to only capture touches within these rects

## Testing
- `go test -tags test ./...` *(fails: X11 Xrandr missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ae5bebce0832a99ea72547198c0be