### PR TITLE
Scale vector strokes for hiDPI

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -108,7 +108,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					op.GeoM.Translate(left, top)
 					screen.DrawImage(img, op)
 					if hover {
-						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
+						s := vectorScale()
+						vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2*s, dotClr, false)
 					}
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["g"+name])
@@ -124,7 +125,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
 			if hover {
-				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
+				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2*vectorScale(), dotClr, false)
 			}
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["g"+name])
@@ -167,7 +168,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					op.GeoM.Translate(x-w/2, y-h/2)
 					screen.DrawImage(img, op)
 					if hover {
-						vector.StrokeRect(screen, float32(x-w/2), float32(y-h/2), float32(w), float32(h), 2, dotClr, false)
+						vector.StrokeRect(screen, float32(x-w/2), float32(y-h/2), float32(w), float32(h), 2*vectorScale(), dotClr, false)
 					}
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["p"+name])
@@ -181,7 +182,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 
 			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
 			if hover {
-				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
+				vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2*vectorScale(), dotClr, false)
 			}
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["p"+name])
@@ -227,7 +228,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				y0 := math.Round((10 + spacing + spacing*float64(g.selectedBiome)) - g.biomeScroll)
 				h := math.Round(spacing)
 				w := math.Round(float64(g.legend.Bounds().Dx()))
-				vector.StrokeRect(screen, 0.5, float32(y0)-4, float32(w)-1, float32(h)-1, 2, highlightColor, false)
+				vector.StrokeRect(screen, 0.5, float32(y0)-4, float32(w)-1, float32(h)-1, 2*vectorScale(), highlightColor, false)
 			}
 			if useNumbers && !g.screenshotMode {
 				g.drawNumberLegend(screen)
@@ -251,7 +252,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				op.GeoM.Translate(float64(sr.Min.X)+(float64(size)-w)/2, float64(sr.Min.Y)+(float64(size)-h)/2)
 				screen.DrawImage(cam, op)
 			}
-			vector.StrokeCircle(screen, scx, scy, float32(size)/2, 1, buttonBorderColor, true)
+			vector.StrokeCircle(screen, scx, scy, float32(size)/2, 1*vectorScale(), buttonBorderColor, true)
 
 			hr := g.helpRect()
 			cx := float32(hr.Min.X + size/2)
@@ -266,7 +267,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				op.GeoM.Translate(float64(hr.Min.X)+(float64(size)-w)/2, float64(hr.Min.Y)+(float64(size)-h)/2)
 				screen.DrawImage(helpImg, op)
 			}
-			vector.StrokeCircle(screen, cx, cy, float32(size)/2, 1, buttonBorderColor, true)
+			vector.StrokeCircle(screen, cx, cy, float32(size)/2, 1*vectorScale(), buttonBorderColor, true)
 
 			or := g.optionsRect()
 			ocx := float32(or.Min.X + size/2)
@@ -281,7 +282,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				op.GeoM.Translate(float64(or.Min.X)+(float64(size)-w)/2, float64(or.Min.Y)+(float64(size)-h)/2)
 				screen.DrawImage(gear, op)
 			}
-			vector.StrokeCircle(screen, ocx, ocy, float32(size)/2, 1, buttonBorderColor, true)
+			vector.StrokeCircle(screen, ocx, ocy, float32(size)/2, 1*vectorScale(), buttonBorderColor, true)
 
 			gr := g.geyserRect()
 			gcx := float32(gr.Min.X + size/2)
@@ -296,7 +297,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				op.GeoM.Translate(float64(gr.Min.X)+(float64(size)-w)/2, float64(gr.Min.Y)+(float64(size)-h)/2)
 				screen.DrawImage(icon, op)
 			}
-			vector.StrokeCircle(screen, gcx, gcy, float32(size)/2, 1, buttonBorderColor, true)
+			vector.StrokeCircle(screen, gcx, gcy, float32(size)/2, 1*vectorScale(), buttonBorderColor, true)
 
 			if g.hoverIcon != hoverNone {
 				switch g.hoverIcon {
@@ -337,7 +338,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					top := math.Round(y - h/2)
 					op.GeoM.Translate(left, top)
 					screen.DrawImage(img, op)
-					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
+					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2*vectorScale(), dotClr, false)
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["g"+name])
 					}
@@ -349,7 +350,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 
 			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
-			vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2, dotClr, false)
+			vector.StrokeRect(screen, float32(x-3), float32(y-3), 6, 6, 2*vectorScale(), dotClr, false)
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["g"+name])
 			}
@@ -382,7 +383,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 					top := math.Round(y - h/2)
 					op.GeoM.Translate(left, top)
 					screen.DrawImage(img, op)
-					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2, dotClr, false)
+					vector.StrokeRect(screen, float32(left)+0.5, float32(top)+0.5, float32(math.Round(w))-1, float32(math.Round(h))-1, 2*vectorScale(), dotClr, false)
 					if useNumbers {
 						formatted = strconv.Itoa(g.legendMap["p"+name])
 					}
@@ -394,7 +395,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			}
 
 			vector.DrawFilledRect(screen, float32(x-2), float32(y-2), 4, 4, dotClr, true)
-			vector.StrokeRect(screen, float32(x-3), float32(y-1), 6, 6, 2, dotClr, false)
+			vector.StrokeRect(screen, float32(x-3), float32(y-1), 6, 6, 2*vectorScale(), dotClr, false)
 			if useNumbers {
 				formatted = strconv.Itoa(g.legendMap["p"+name])
 			}

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -20,8 +20,9 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		cx := g.width / 2
 		cy := g.height / 2
 		crossClr := color.RGBA{255, 255, 255, 30}
-		vector.StrokeLine(screen, float32(cx-CrosshairSize), float32(cy), float32(cx+CrosshairSize), float32(cy), 1, crossClr, true)
-		vector.StrokeLine(screen, float32(cx), float32(cy-CrosshairSize), float32(cx), float32(cy+CrosshairSize), 1, crossClr, true)
+		s := vectorScale()
+		vector.StrokeLine(screen, float32(cx-CrosshairSize), float32(cy), float32(cx+CrosshairSize), float32(cy), 1*s, crossClr, true)
+		vector.StrokeLine(screen, float32(cx), float32(cy-CrosshairSize), float32(cx), float32(cy+CrosshairSize), 1*s, crossClr, true)
 		if g.showItemNames {
 			worldX := int(math.Round(((float64(cx) - g.camX) / g.zoom) / 2))
 			worldY := int(math.Round(((float64(cy) - g.camY) / g.zoom) / 2))

--- a/drawing.go
+++ b/drawing.go
@@ -62,7 +62,7 @@ func (g *Game) drawInfoPanel(dst *ebiten.Image, text string, icon *ebiten.Image,
 	h += 8
 	img := ebiten.NewImage(w, h)
 	vector.DrawFilledRect(img, 0, 0, float32(w), float32(h), color.RGBA{0, 0, 0, InfoPanelAlpha}, false)
-	vector.StrokeRect(img, 0.5, 0.5, float32(w)-1, float32(h)-1, 1, buttonBorderColor, false)
+	vector.StrokeRect(img, 0.5, 0.5, float32(w)-1, float32(h)-1, 1*vectorScale(), buttonBorderColor, false)
 	if icon != nil {
 		opIcon := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 		scaleIcon := float64(InfoIconSize) / math.Max(float64(icon.Bounds().Dx()), float64(icon.Bounds().Dy()))

--- a/legend.go
+++ b/legend.go
@@ -128,7 +128,7 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 		spacing := float64(rowSpacing())
 		hy := y + (10 + spacing*float64(g.selectedItem+1))
 		hh := spacing
-		vector.StrokeRect(dst, float32(math.Round(x))+0.5, float32(math.Round(hy))-4, float32(math.Round(w))-1, float32(math.Round(hh))-1, 2, highlightColor, false)
+		vector.StrokeRect(dst, float32(math.Round(x))+0.5, float32(math.Round(hy))-4, float32(math.Round(w))-1, float32(math.Round(hh))-1, 2*vectorScale(), highlightColor, false)
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -27,8 +27,9 @@ func drawButton(dst *ebiten.Image, rect image.Rectangle, active bool) {
 func drawCloseButton(dst *ebiten.Image, rect image.Rectangle) {
 	drawButton(dst, rect, false)
 	pad := float32(rect.Dx()) * 0.25
-	vector.StrokeLine(dst, float32(rect.Min.X)+pad, float32(rect.Min.Y)+pad, float32(rect.Max.X)-pad, float32(rect.Max.Y)-pad, 2, buttonBorderColor, true)
-	vector.StrokeLine(dst, float32(rect.Min.X)+pad, float32(rect.Max.Y)-pad, float32(rect.Max.X)-pad, float32(rect.Min.Y)+pad, 2, buttonBorderColor, true)
+	s := vectorScale()
+	vector.StrokeLine(dst, float32(rect.Min.X)+pad, float32(rect.Min.Y)+pad, float32(rect.Max.X)-pad, float32(rect.Max.Y)-pad, 2*s, buttonBorderColor, true)
+	vector.StrokeLine(dst, float32(rect.Min.X)+pad, float32(rect.Max.Y)-pad, float32(rect.Max.X)-pad, float32(rect.Min.Y)+pad, 2*s, buttonBorderColor, true)
 }
 
 // drawRoundedRect fills and strokes a rectangle with a corner radius.
@@ -60,12 +61,13 @@ func drawRoundedRect(dst *ebiten.Image, rect image.Rectangle, radius float32, fi
 	op := &ebiten.DrawTrianglesOptions{AntiAlias: true, ColorScaleMode: ebiten.ColorScaleModePremultipliedAlpha}
 	dst.DrawTriangles(vs, is, whitePixel, op)
 
-	vector.StrokeLine(dst, x0+r, y0, x0+w-r, y0, 1, border, true)
-	vector.StrokeLine(dst, x0+w, y0+r, x0+w, y0+h-r, 1, border, true)
-	vector.StrokeLine(dst, x0+r, y0+h, x0+w-r, y0+h, 1, border, true)
-	vector.StrokeLine(dst, x0, y0+r, x0, y0+h-r, 1, border, true)
-	vector.StrokeLine(dst, x0+r, y0, x0, y0+r, 1, border, true)
-	vector.StrokeLine(dst, x0+w-r, y0, x0+w, y0+r, 1, border, true)
-	vector.StrokeLine(dst, x0, y0+h-r, x0+r, y0+h, 1, border, true)
-	vector.StrokeLine(dst, x0+w, y0+h-r, x0+w-r, y0+h, 1, border, true)
+	s := vectorScale()
+	vector.StrokeLine(dst, x0+r, y0, x0+w-r, y0, 1*s, border, true)
+	vector.StrokeLine(dst, x0+w, y0+r, x0+w, y0+h-r, 1*s, border, true)
+	vector.StrokeLine(dst, x0+r, y0+h, x0+w-r, y0+h, 1*s, border, true)
+	vector.StrokeLine(dst, x0, y0+r, x0, y0+h-r, 1*s, border, true)
+	vector.StrokeLine(dst, x0+r, y0, x0, y0+r, 1*s, border, true)
+	vector.StrokeLine(dst, x0+w-r, y0, x0+w, y0+r, 1*s, border, true)
+	vector.StrokeLine(dst, x0, y0+h-r, x0+r, y0+h, 1*s, border, true)
+	vector.StrokeLine(dst, x0+w, y0+h-r, x0+w-r, y0+h, 1*s, border, true)
 }

--- a/vector_scale.go
+++ b/vector_scale.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/hajimehoshi/ebiten/v2"
+
+func vectorScale() float32 {
+	return float32(ebiten.Monitor().DeviceScaleFactor())
+}


### PR DESCRIPTION
## Summary
- add `vectorScale` helper
- scale button and UI outlines using monitor scale factor
- adjust crosshair thickness
- ensure info panels and legends scale correctly in HiDPI mode

## Testing
- `go test -tags test ./...` *(fails: missing X11 dev headers)*

------
https://chatgpt.com/codex/tasks/task_e_686af063ed68832a8331673fdde725d4