### PR TITLE
Remove goroutines

### DIFF
--- a/game_helpers.go
+++ b/game_helpers.go
@@ -51,7 +51,8 @@ type Game struct {
 	lastWheel         time.Time
 	loading           bool
 	status            string
-	iconResults       chan loadedIcon
+	iconsToLoad       []string
+	iconLoadIndex     int
 	coord             string
 	mobile            bool
 	showInfo          bool
@@ -323,12 +324,6 @@ func abs(a int) int {
 }
 
 func (g *Game) startIconLoader(names []string) {
-	g.iconResults = make(chan loadedIcon, len(names))
-	go func() {
-		for _, n := range names {
-			img, _ := loadImageFile(n)
-			g.iconResults <- loadedIcon{name: n, img: img}
-		}
-		close(g.iconResults)
-	}()
+	g.iconsToLoad = append([]string(nil), names...)
+	g.iconLoadIndex = 0
 }

--- a/main.go
+++ b/main.go
@@ -56,90 +56,7 @@ func main() {
 		selectedItem:      -1,
 	}
 	registerFontChange(game.invalidateLegends)
-	go func(id string) {
-		//fmt.Println("Fetching:", *coord)
-		cborData, err := fetchSeedCBOR(*coord)
-		if err != nil {
-			game.status = "Error: " + err.Error()
-			game.statusError = false
-			game.needsRedraw = true
-			game.loading = false
-			return
-		}
-		seed, err := decodeSeed(cborData)
-		game.asteroids = seed.Asteroids
-		if err != nil {
-			game.status = "Error: " + err.Error()
-			game.statusError = false
-			game.needsRedraw = true
-			game.loading = false
-			return
-		}
-		astIdxSel := 0
-		if game.asteroidSpecified {
-			astIdxSel = asteroidIndexByID(seed.Asteroids, id)
-			if astIdxSel < 0 {
-				game.status = fmt.Sprintf("%s\nAsteroid ID: %s\nThis location does not contain Asteroid ID: %s", game.coord, id, id)
-				if len(seed.Asteroids) > 0 {
-					valid := make([]string, 0, len(seed.Asteroids))
-					for _, a := range seed.Asteroids {
-						valid = append(valid, a.ID)
-					}
-					lines := make([]string, 0, (len(valid)+2)/3)
-					for i, v := range valid {
-						if i%3 == 0 {
-							lines = append(lines, v)
-						} else {
-							lines[len(lines)-1] = lines[len(lines)-1] + ", " + v
-						}
-					}
-					game.status += fmt.Sprintf("\nValid IDs: %s", strings.Join(lines, "\n"))
-				}
-				game.statusError = true
-				game.needsRedraw = true
-				game.loading = false
-				return
-			}
-		}
-		ast := seed.Asteroids[astIdxSel]
-		game.invalidateLegends()
-		game.legendMap = nil
-		game.legendEntries = nil
-		game.legendColors = nil
-		game.selectedItem = -1
-		game.itemScroll = 0
-		game.asteroidID = ast.ID
-		bps := parseBiomePaths(ast.BiomePaths)
-		game.geysers = ast.Geysers
-		game.pois = ast.POIs
-		game.biomes = bps
-		game.astWidth = ast.SizeX
-		game.astHeight = ast.SizeY
-		game.legend, game.legendBiomes = buildLegendImage(bps)
-		game.fitOnLoad = true
-		game.biomeTextures = loadBiomeTextures()
-		names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
-		set := make(map[string]struct{})
-		for _, gy := range ast.Geysers {
-			if n := iconForGeyser(gy.ID); n != "" {
-				if _, ok := set[n]; !ok {
-					set[n] = struct{}{}
-					names = append(names, n)
-				}
-			}
-		}
-		for _, poi := range ast.POIs {
-			if n := iconForPOI(poi.ID); n != "" {
-				if _, ok := set[n]; !ok {
-					set[n] = struct{}{}
-					names = append(names, n)
-				}
-			}
-		}
-		game.startIconLoader(names)
-		game.loading = false
-		game.needsRedraw = true
-	}(asteroidIDVal)
+	loadGameData(game, *coord, asteroidIDVal)
 	if *screenshot != "" {
 
 		game.screenshotPath = *screenshot
@@ -157,4 +74,88 @@ func main() {
 	if err := ebiten.RunGame(game); err != nil {
 		fmt.Println("Error running game:", err)
 	}
+}
+
+func loadGameData(game *Game, coord, asteroidID string) {
+	cborData, err := fetchSeedCBOR(coord)
+	if err != nil {
+		game.status = "Error: " + err.Error()
+		game.statusError = false
+		game.needsRedraw = true
+		game.loading = false
+		return
+	}
+	seed, err := decodeSeed(cborData)
+	game.asteroids = seed.Asteroids
+	if err != nil {
+		game.status = "Error: " + err.Error()
+		game.statusError = false
+		game.needsRedraw = true
+		game.loading = false
+		return
+	}
+	astIdxSel := 0
+	if game.asteroidSpecified {
+		astIdxSel = asteroidIndexByID(seed.Asteroids, asteroidID)
+		if astIdxSel < 0 {
+			game.status = fmt.Sprintf("%s\nAsteroid ID: %s\nThis location does not contain Asteroid ID: %s", game.coord, asteroidID, asteroidID)
+			if len(seed.Asteroids) > 0 {
+				valid := make([]string, 0, len(seed.Asteroids))
+				for _, a := range seed.Asteroids {
+					valid = append(valid, a.ID)
+				}
+				lines := make([]string, 0, (len(valid)+2)/3)
+				for i, v := range valid {
+					if i%3 == 0 {
+						lines = append(lines, v)
+					} else {
+						lines[len(lines)-1] = lines[len(lines)-1] + ", " + v
+					}
+				}
+				game.status += fmt.Sprintf("\nValid IDs: %s", strings.Join(lines, "\n"))
+			}
+			game.statusError = true
+			game.needsRedraw = true
+			game.loading = false
+			return
+		}
+	}
+	ast := seed.Asteroids[astIdxSel]
+	game.invalidateLegends()
+	game.legendMap = nil
+	game.legendEntries = nil
+	game.legendColors = nil
+	game.selectedItem = -1
+	game.itemScroll = 0
+	game.asteroidID = ast.ID
+	bps := parseBiomePaths(ast.BiomePaths)
+	game.geysers = ast.Geysers
+	game.pois = ast.POIs
+	game.biomes = bps
+	game.astWidth = ast.SizeX
+	game.astHeight = ast.SizeY
+	game.legend, game.legendBiomes = buildLegendImage(bps)
+	game.fitOnLoad = true
+	game.biomeTextures = loadBiomeTextures()
+	names := []string{"../icons/camera.png", "../icons/help.png", "../icons/gear.png", "geyser_water.png"}
+	set := make(map[string]struct{})
+	for _, gy := range ast.Geysers {
+		if n := iconForGeyser(gy.ID); n != "" {
+			if _, ok := set[n]; !ok {
+				set[n] = struct{}{}
+				names = append(names, n)
+			}
+		}
+	}
+	for _, poi := range ast.POIs {
+		if n := iconForPOI(poi.ID); n != "" {
+			if _, ok := set[n]; !ok {
+				set[n] = struct{}{}
+				names = append(names, n)
+			}
+		}
+	}
+	game.startIconLoader(names)
+	game.loading = false
+	game.needsRedraw = true
 }

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -31,20 +31,14 @@ func (g *Game) checkRedrawTriggers() {
 }
 
 func (g *Game) handleIconLoading() {
-	for g.iconResults != nil {
-		select {
-		case li, ok := <-g.iconResults:
-			if !ok {
-				g.iconResults = nil
-				continue
-			}
-			if g.icons != nil {
-				g.icons[li.name] = li.img
-			}
-			g.needsRedraw = true
-		default:
-			return
+	if g.iconLoadIndex < len(g.iconsToLoad) {
+		name := g.iconsToLoad[g.iconLoadIndex]
+		img, _ := loadImageFile(name)
+		if g.icons != nil {
+			g.icons[name] = img
 		}
+		g.iconLoadIndex++
+		g.needsRedraw = true
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace goroutine-based loading with synchronous helper `loadGameData`
- sequentially load icons without channels
- store icon load queue in the `Game` struct

## Testing
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af947ec20832aa7e916f4667938c3