### PR TITLE
Improve options and UI scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Oni-SeedView is a small utility for inspecting **Oxygen Not Included** seed data
 * Hover over geyser or POI icons to show an information panel. Clicking or tapping centers the item and pins it in place while panning.
 * Hover over the bottom icons for tooltips describing their actions. Tooltips automatically stay within the window bounds.
 * A help icon displays the available controls at any time. An X button closes the overlay.
-* A gear icon opens an options menu for toggling features like textures, Vsync, power saver mode and linear filtering along with item labels, legends and number labels. You can also adjust font size and icon size and view the current FPS.
+* A gear icon opens an options menu for toggling features like textures, Vsync, power saver mode, HiDPI mode and linear filtering along with item labels, legends and number labels. You can also adjust icon size and UI scale and view the current FPS.
 * Crosshairs at the center show the current world coordinates, useful for lining up precise screenshots.
 * Click the down-arrow next to the asteroid name to choose another asteroid.
 * A geyser icon opens a scrollable list of all geysers present on the map.

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -92,6 +92,7 @@ type Game struct {
 	iconScale     float64
 	smartRender   bool
 	linearFilter  bool
+	hidpi         bool
 
 	noColor   bool
 	ssNoColor bool

--- a/layout.go
+++ b/layout.go
@@ -2,11 +2,20 @@ package main
 
 import (
 	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 	screenW := outsideWidth
 	screenH := outsideHeight
+
+	scale := ebiten.Monitor().DeviceScaleFactor()
+	if !g.hidpi {
+		scale = 1
+	}
+	base := math.Min(float64(screenW)*scale/float64(DefaultWidth), float64(screenH)*scale/float64(DefaultHeight))
+	setUIBaseScale(base)
 
 	/*
 		if !g.screenshotMode {

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 		iconScale:         1.0,
 		smartRender:       true,
 		linearFilter:      true,
+		hidpi:             true,
 		ssQuality:         1,
 		hoverBiome:        -1,
 		hoverItem:         -1,

--- a/options_menu.go
+++ b/options_menu.go
@@ -83,10 +83,10 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 
 	label := "Icon Size"
 	drawText(img, label, pad, y, false)
-	tw, _ = textDimensions(label)
-	bx = pad + tw + pad
-	minus = image.Rect(bx, y-uiScaled(4), bx+uiScaled(20), y-uiScaled(4)+menuButtonHeight())
-	plus = image.Rect(bx+uiScaled(24), y-uiScaled(4), bx+uiScaled(44), y-uiScaled(4)+menuButtonHeight())
+	tw, _ := textDimensions(label)
+	bx := pad + tw + pad
+	minus := image.Rect(bx, y-uiScaled(4), bx+uiScaled(20), y-uiScaled(4)+menuButtonHeight())
+	plus := image.Rect(bx+uiScaled(24), y-uiScaled(4), bx+uiScaled(44), y-uiScaled(4)+menuButtonHeight())
 	drawButton(img, minus, false)
 	drawPlusMinus(img, minus, true)
 	drawButton(img, plus, false)

--- a/options_menu.go
+++ b/options_menu.go
@@ -15,20 +15,19 @@ func (g *Game) optionsRect() image.Rectangle {
 }
 
 func (g *Game) optionsMenuSize() (int, int) {
-	fontLabel := fmt.Sprintf("Font Size [-] [+] %.0fpt", fontSize)
 	uiLabel := fmt.Sprintf("UI Scale [-] [+] %.0f%%", uiScale*100)
 	labels := []string{
 		OptionsMenuTitle,
 		"Show Item Names",
 		"Show Legends",
 		"Use Item Numbers",
-		fontLabel,
 		"Icon Size [-] [+]",
 		uiLabel,
 		"Textures",
 		"Vsync",
 		"Power Saver",
 		"Linear Filtering",
+		"HiDPI Mode",
 		"FPS: 60.0",
 		"Version: " + ClientVersion,
 		"Close",
@@ -82,21 +81,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Show Legends", g.showLegend)
 	drawToggle("Use Item Numbers", g.useNumbers)
 
-	label := "Font Size"
-	drawText(img, label, pad, y, false)
-	tw, _ := textDimensions(label)
-	bx := pad + tw + pad
-	minus := image.Rect(bx, y-uiScaled(4), bx+uiScaled(20), y-uiScaled(4)+menuButtonHeight())
-	plus := image.Rect(bx+uiScaled(24), y-uiScaled(4), bx+uiScaled(44), y-uiScaled(4)+menuButtonHeight())
-	drawButton(img, minus, false)
-	drawPlusMinus(img, minus, true)
-	drawButton(img, plus, false)
-	drawPlusMinus(img, plus, false)
-	sizeStr := fmt.Sprintf("%.0fpt", fontSize)
-	drawText(img, sizeStr, plus.Max.X+pad, y, false)
-	y += menuSpacing()
-
-	label = "Icon Size"
+	label := "Icon Size"
 	drawText(img, label, pad, y, false)
 	tw, _ = textDimensions(label)
 	bx = pad + tw + pad
@@ -127,6 +112,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Vsync", g.vsync)
 	drawToggle("Power Saver", g.smartRender)
 	drawToggle("Linear Filtering", g.linearFilter)
+	drawToggle("HiDPI Mode", g.hidpi)
 
 	fps := fmt.Sprintf("FPS: %.1f", ebiten.ActualFPS())
 	drawText(img, fps, pad, y, false)
@@ -187,38 +173,20 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	}
 	y += menuSpacing()
 
-	// Font Size buttons
-	labelW, _ := textDimensions("Font Size")
+	// Icon Size buttons
+	labelW, _ := textDimensions("Icon Size")
 	bx := uiScaled(6) + labelW + uiScaled(6)
 	minus := image.Rect(bx, y-uiScaled(4), bx+uiScaled(20), y-uiScaled(4)+menuButtonHeight())
 	plus := image.Rect(bx+uiScaled(24), y-uiScaled(4), bx+uiScaled(44), y-uiScaled(4)+menuButtonHeight())
 	if minus.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-		decreaseFontSize()
-		if max := g.maxBiomeScroll(); max == 0 {
-			g.biomeScroll = 0
-		} else if g.biomeScroll > max {
-			g.biomeScroll = max
-		}
-		if max := g.maxItemScroll(); max == 0 {
-			g.itemScroll = 0
-		} else if g.itemScroll > max {
-			g.itemScroll = max
+		if g.iconScale > 0.25 {
+			g.iconScale -= 0.25
 		}
 		g.needsRedraw = true
 		return true
 	}
 	if plus.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-		increaseFontSize()
-		if max := g.maxBiomeScroll(); max == 0 {
-			g.biomeScroll = 0
-		} else if g.biomeScroll > max {
-			g.biomeScroll = max
-		}
-		if max := g.maxItemScroll(); max == 0 {
-			g.itemScroll = 0
-		} else if g.itemScroll > max {
-			g.itemScroll = max
-		}
+		g.iconScale += 0.25
 		g.needsRedraw = true
 		return true
 	}
@@ -294,6 +262,15 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	r = image.Rect(uiScaled(4), y-uiScaled(4), w-uiScaled(4), y-uiScaled(4)+menuButtonHeight())
 	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		g.linearFilter = !g.linearFilter
+		g.needsRedraw = true
+		return true
+	}
+	y += menuSpacing()
+
+	// HiDPI Mode
+	r = image.Rect(uiScaled(4), y-uiScaled(4), w-uiScaled(4), y-uiScaled(4)+menuButtonHeight())
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.hidpi = !g.hidpi
 		g.needsRedraw = true
 		return true
 	}

--- a/ui_scale.go
+++ b/ui_scale.go
@@ -2,14 +2,35 @@ package main
 
 import "math"
 
-var uiScale = 1.0
+var (
+	uiBaseScale = 1.0
+	uiUserScale = 1.0
+	uiScale     = 1.0
+)
+
+func updateUIScale() {
+	total := uiBaseScale * uiUserScale
+	if total < 0.5 {
+		total = 0.5
+	}
+	if math.Abs(total-uiScale) < 0.01 {
+		return
+	}
+	uiScale = total
+	setFontSize(baseFontSize * uiScale)
+}
 
 func setUIScale(scale float64) {
 	if scale < 0.5 {
 		scale = 0.5
 	}
-	uiScale = scale
-	setFontSize(baseFontSize * uiScale)
+	uiUserScale = scale
+	updateUIScale()
+}
+
+func setUIBaseScale(scale float64) {
+	uiBaseScale = scale
+	updateUIScale()
 }
 
 func uiScaled(v int) int {


### PR DESCRIPTION
## Summary
- remove manual font size control
- auto-adjust UI scale using the window resolution and add HiDPI toggle
- track HiDPI preference and update base UI scale dynamically
- document new UI scale behaviour in the README

## Testing
- `gofmt -w *.go`
- `find . -name '*.go' | xargs gofmt -w`
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686afe872544832abecfc31c51c14647