### PR TITLE
Add HiDPI mode option

### DIFF
--- a/fonts.go
+++ b/fonts.go
@@ -30,7 +30,7 @@ func loadFont(size float64) font.Face {
 			panic("failed to parse font: " + err.Error())
 		}
 	}
-	const dpi = 72
+	dpi := 72.0 * getHiDPIScale()
 	face, err := opentype.NewFace(fontParsed, &opentype.FaceOptions{Size: size, DPI: dpi, Hinting: font.HintingFull})
 	if err != nil {
 		panic("failed to create font face: " + err.Error())

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -92,6 +92,7 @@ type Game struct {
 	iconScale     float64
 	smartRender   bool
 	linearFilter  bool
+	hidpi         bool
 
 	noColor   bool
 	ssNoColor bool

--- a/hidpi.go
+++ b/hidpi.go
@@ -1,0 +1,31 @@
+package main
+
+import "github.com/hajimehoshi/ebiten/v2"
+
+var hiDPIEnabled = true
+var hiDPIScale = 1.0
+
+func getHiDPIScale() float64 {
+	if !hiDPIEnabled {
+		return 1.0
+	}
+	if hiDPIScale == 1.0 {
+		s := ebiten.Monitor().DeviceScaleFactor()
+		if s > 0 {
+			hiDPIScale = s
+		}
+	}
+	return hiDPIScale
+}
+
+func setHiDPI(enabled bool) {
+	hiDPIEnabled = enabled
+	hiDPIScale = 1.0
+	if enabled {
+		if s := ebiten.Monitor().DeviceScaleFactor(); s > 0 {
+			hiDPIScale = s
+		}
+	}
+	// Reload fonts with new DPI
+	setFontSize(fontSize)
+}

--- a/layout.go
+++ b/layout.go
@@ -5,8 +5,9 @@ import (
 )
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	screenW := outsideWidth
-	screenH := outsideHeight
+	scale := getHiDPIScale()
+	screenW := int(float64(outsideWidth) * scale)
+	screenH := int(float64(outsideHeight) * scale)
 
 	/*
 		if !g.screenshotMode {

--- a/main.go
+++ b/main.go
@@ -47,12 +47,14 @@ func main() {
 		iconScale:         1.0,
 		smartRender:       true,
 		linearFilter:      true,
+		hidpi:             true,
 		ssQuality:         1,
 		hoverBiome:        -1,
 		hoverItem:         -1,
 		selectedBiome:     -1,
 		selectedItem:      -1,
 	}
+	setHiDPI(game.hidpi)
 	registerFontChange(game.invalidateLegends)
 	loadGameData(game, *coord, asteroidIDVal)
 	if *screenshot != "" {

--- a/options_menu.go
+++ b/options_menu.go
@@ -27,6 +27,7 @@ func (g *Game) optionsMenuSize() (int, int) {
 		"Vsync",
 		"Power Saver",
 		"Linear Filtering",
+		"HiDPI",
 		"FPS: 60.0",
 		"Version: " + ClientVersion,
 		"Close",
@@ -111,6 +112,7 @@ func (g *Game) drawOptionsMenu(dst *ebiten.Image) {
 	drawToggle("Vsync", g.vsync)
 	drawToggle("Power Saver", g.smartRender)
 	drawToggle("Linear Filtering", g.linearFilter)
+	drawToggle("HiDPI", g.hidpi)
 
 	fps := fmt.Sprintf("FPS: %.1f", ebiten.ActualFPS())
 	drawText(img, fps, pad, y, false)
@@ -241,6 +243,16 @@ func (g *Game) clickOptionsMenu(mx, my int) bool {
 	r = image.Rect(uiScaled(4), y-uiScaled(4), w-uiScaled(4), y-uiScaled(4)+menuButtonHeight())
 	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 		g.linearFilter = !g.linearFilter
+		g.needsRedraw = true
+		return true
+	}
+	y += menuSpacing()
+
+	// HiDPI
+	r = image.Rect(uiScaled(4), y-uiScaled(4), w-uiScaled(4), y-uiScaled(4)+menuButtonHeight())
+	if r.Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		g.hidpi = !g.hidpi
+		setHiDPI(g.hidpi)
 		g.needsRedraw = true
 		return true
 	}


### PR DESCRIPTION
## Summary
- implement HiDPI scaling support via new functions in `hidpi.go`
- adjust font loading and layout using the device scale factor
- add `hidpi` field to `Game` and initialize it
- expose HiDPI toggle in the options menu

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b11abc6e8832a8a71d2f74fe1d1e7