### PR TITLE
Improve screenshot BW preview and menu

### DIFF
--- a/const.go
+++ b/const.go
@@ -47,7 +47,7 @@ const (
 	ScreenshotTakingLabel = "Taking Screenshot..."
 	ScreenshotSavedLabel  = "Saved!"
 	ScreenshotBWLabel     = "Black and White"
-	ScreenshotCloseLabel  = "Close"
+	ScreenshotCancelLabel = "Cancel"
 	GeyserRowSpacing      = 60
 	OptionsMenuTitle      = "Options:"
 	AsteroidMenuTitle     = "Asteroids:"

--- a/draw.go
+++ b/draw.go
@@ -55,8 +55,14 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if !ok {
 				clr = color.RGBA{60, 60, 60, 255}
 			}
+			if g.noColor {
+				clr = color.White
+			}
 			highlight := g.selectedBiome >= 0 && g.selectedBiome < len(g.legendBiomes) && g.legendBiomes[g.selectedBiome] == bp.Name
 			texClr := clr
+			if g.noColor {
+				texClr = color.White
+			}
 			if g.selectedBiome >= 0 && !highlight {
 				texClr = color.RGBA{100, 100, 100, texClr.A}
 			}

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -20,7 +20,7 @@ func (g *Game) screenshotRect() image.Rectangle {
 
 func (g *Game) screenshotMenuSize() (int, int) {
 	labels := append([]string{ScreenshotMenuTitle}, ScreenshotQualities...)
-	labels = append(labels, ScreenshotBWLabel, ScreenshotSaveLabel, ScreenshotCloseLabel)
+	labels = append(labels, ScreenshotBWLabel, ScreenshotSaveLabel, ScreenshotCancelLabel)
 	itemCount := len(labels)
 	allLabels := append([]string(nil), labels...)
 	allLabels = append(allLabels, ScreenshotTakingLabel, ScreenshotSavedLabel)
@@ -32,7 +32,8 @@ func (g *Game) screenshotMenuSize() (int, int) {
 		}
 	}
 	w := maxW + uiScaled(4)
-	h := (itemCount+1)*menuSpacing() + uiScaled(4)
+	// Extra spacing after quality options and the B&W toggle
+	h := (itemCount+2)*menuSpacing() + uiScaled(6)
 	return w, h
 }
 
@@ -67,7 +68,7 @@ func (g *Game) drawScreenshotMenu(dst *ebiten.Image) {
 		label = ScreenshotSavedLabel
 	}
 	items := append([]string(nil), ScreenshotQualities...)
-	items = append(items, ScreenshotBWLabel, label, ScreenshotCloseLabel)
+	items = append(items, ScreenshotBWLabel, label, ScreenshotCancelLabel)
 	y := pad + menuSpacing()
 	for i, it := range items {
 		btn := image.Rect(uiScaled(4), y-uiScaled(4), w-uiScaled(4), y-uiScaled(4)+menuButtonHeight())
@@ -111,7 +112,7 @@ func (g *Game) clickScreenshotMenu(mx, my int) bool {
 	mx = x
 	my = y
 	items := append([]string(nil), ScreenshotQualities...)
-	items = append(items, ScreenshotBWLabel, ScreenshotSaveLabel, ScreenshotCloseLabel)
+	items = append(items, ScreenshotBWLabel, ScreenshotSaveLabel, ScreenshotCancelLabel)
 	y = uiScaled(6) + menuSpacing()
 	w, _ := g.screenshotMenuSize()
 	for i := range items {
@@ -122,12 +123,14 @@ func (g *Game) clickScreenshotMenu(mx, my int) bool {
 				g.ssQuality = i
 			case len(ScreenshotQualities):
 				g.ssNoColor = !g.ssNoColor
+				g.noColor = g.ssNoColor
 			case len(ScreenshotQualities) + 1:
 				if g.ssPending == 0 {
 					g.ssPending = 2
 				}
 			case len(ScreenshotQualities) + 2:
 				g.showShotMenu = false
+				g.noColor = false
 			}
 			g.needsRedraw = true
 			return true

--- a/update.go
+++ b/update.go
@@ -169,6 +169,7 @@ func (g *Game) Update() error {
 				if !g.clickScreenshotMenu(mx, my) {
 					if !g.screenshotMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 						g.showShotMenu = false
+						g.noColor = false
 						g.needsRedraw = true
 					}
 				}
@@ -184,6 +185,7 @@ func (g *Game) Update() error {
 			}
 		} else if justPressed && g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showShotMenu = true
+			g.noColor = g.ssNoColor
 			g.needsRedraw = true
 		} else if justPressed && g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showOptions = true

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -34,6 +34,7 @@ func (g *Game) processScreenshot() {
 			g.saveScreenshot()
 			g.ssSaved = time.Now()
 			g.showShotMenu = false
+			g.noColor = false
 			g.skipClickTicks = 1
 		}
 		g.ssPending--


### PR DESCRIPTION
## Summary
- rename screenshot close button to Cancel
- enlarge screenshot menu so Cancel is visible
- preview black & white mode while menu is open
- reset preview when menu is closed or screenshot finishes
- brighten BW screenshots by ignoring biome colors

## Testing
- `go test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_686b210837ac832ab550c23456137b7a