### PR TITLE
Improve asteroid menu scaling and text truncation

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -14,10 +14,11 @@ func (g *Game) asteroidArrowRect() image.Rectangle {
 	if name == "" {
 		name = "Unknown"
 	}
+	name = truncateString(name, 32)
 	text := "Asteroid: " + name
 	w, _ := textDimensions(text)
 	x := g.width/2 + w/2 + uiScaled(4)
-	size := int(float64(12) * fontScale())
+	size := uiScaled(12)
 	baseline := seedBaseline() + notoFont.Metrics().Height.Ceil() + uiScaled(4)
 	y := baseline + notoFont.Metrics().Descent.Ceil() + uiScaled(4) - size/2
 	return image.Rect(x, y, x+size, y+size)
@@ -38,6 +39,7 @@ func (g *Game) asteroidInfoRect() image.Rectangle {
 	if name == "" {
 		name = "Unknown"
 	}
+	name = truncateString(name, 32)
 	astText := "Asteroid: " + name
 	aw, ah := textDimensions(astText)
 	ax := g.width/2 - aw/2
@@ -91,7 +93,8 @@ func drawCheck(dst *ebiten.Image, rect image.Rectangle) {
 func (g *Game) asteroidMenuSize() (int, int) {
 	maxW, _ := textDimensions(AsteroidMenuTitle)
 	for _, a := range g.asteroids {
-		w, _ := textDimensions(a.ID)
+		name := truncateString(a.ID, 64)
+		w, _ := textDimensions(name)
 		if w > maxW {
 			maxW = w
 		}
@@ -156,7 +159,8 @@ func (g *Game) drawAsteroidMenu(dst *ebiten.Image) {
 			ck := image.Rect(btn.Min.X+uiScaled(4), btn.Min.Y+uiScaled(4), btn.Min.X+uiScaled(16), btn.Min.Y+uiScaled(16))
 			drawCheck(img, ck)
 		}
-		drawText(img, a.ID, btn.Min.X+uiScaled(20), btn.Min.Y+uiScaled(4), false)
+		name := truncateString(a.ID, 64)
+		drawText(img, name, btn.Min.X+uiScaled(20), btn.Min.Y+uiScaled(4), false)
 		y += menuSpacing()
 	}
 	op := &ebiten.DrawImageOptions{}

--- a/draw.go
+++ b/draw.go
@@ -203,6 +203,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			if aName == "" {
 				aName = "Unknown"
 			}
+			aName = truncateString(aName, 32)
 			astName := fmt.Sprintf("Asteroid: %s", aName)
 
 			x := g.width / 2

--- a/textutil.go
+++ b/textutil.go
@@ -31,3 +31,14 @@ func textDimensions(str string) (int, int) {
 	lineHeight := notoFont.Metrics().Height.Ceil()
 	return width, lineHeight * len(lines)
 }
+
+func truncateString(s string, max int) string {
+	if len([]rune(s)) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}


### PR DESCRIPTION
## Summary
- scale asteroid arrow with UI scale
- cap asteroid name length in main display to 32 characters
- cap asteroid menu names at 64 characters
- add `truncateString` helper

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686b276f9cd8832a9831de1cf953391c