### PR TITLE
Menu toggle delay and unified header background

### DIFF
--- a/const.go
+++ b/const.go
@@ -60,6 +60,11 @@ const (
 	// in WASM to account for faster scroll events.
 	WheelThrottle = 75 * time.Millisecond
 
+	// MenuToggleDelay is the minimum time between clicking an icon and being
+	// able to close the associated menu again. This prevents instant double
+	// toggles from accidental double-clicks.
+	MenuToggleDelay = 250 * time.Millisecond
+
 	// WebAssetBase specifies the path used to fetch image assets
 	// when running in WebAssembly. The assets should be served
 	// relative to the page URL.

--- a/draw.go
+++ b/draw.go
@@ -219,12 +219,15 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			aName = truncateString(aName, 32)
 			astName := fmt.Sprintf("Asteroid: %s", aName)
 
+			rect := g.asteroidInfoRect()
+			vector.DrawFilledRect(screen, float32(rect.Min.X), float32(rect.Min.Y), float32(rect.Dx()), float32(rect.Dy()), color.RGBA{0, 0, 0, 128}, false)
+
 			x := g.width / 2
 			astBase := seedBaseline() + notoFont.Metrics().Height.Ceil() + 4
-			drawTextWithBGScale(screen, astName, x, astBase, 1, true)
+			drawText(screen, astName, x, astBase, true)
 			ar := g.asteroidArrowRect()
 			drawDownArrow(screen, ar, g.showAstMenu)
-			drawTextWithBGScale(screen, label, x, seedBaseline(), 1, true)
+			drawText(screen, label, x, seedBaseline(), true)
 		}
 
 		if g.showLegend {

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -97,6 +97,12 @@ type Game struct {
 	noColor   bool
 	ssNoColor bool
 	grayImage *ebiten.Image
+
+	lastHelpClick     time.Time
+	lastShotClick     time.Time
+	lastOptionsClick  time.Time
+	lastGeyserClick   time.Time
+	lastAsteroidClick time.Time
 }
 
 type label struct {

--- a/update.go
+++ b/update.go
@@ -159,14 +159,28 @@ func (g *Game) Update() error {
 		}
 		g.lastMouseX, g.lastMouseY = mx, my
 		if justPressed && g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.showHelp = !g.showHelp
+			if g.showHelp {
+				if time.Since(g.lastHelpClick) >= MenuToggleDelay {
+					g.showHelp = false
+				}
+			} else {
+				g.showHelp = true
+			}
+			g.lastHelpClick = time.Now()
 			g.needsRedraw = true
 		} else if g.showHelp && justPressed && g.helpCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			g.showHelp = false
 			g.needsRedraw = true
 		} else if g.showShotMenu {
 			if justPressed {
-				if !g.clickScreenshotMenu(mx, my) {
+				if g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+					if time.Since(g.lastShotClick) >= MenuToggleDelay {
+						g.showShotMenu = false
+						g.noColor = false
+					}
+					g.lastShotClick = time.Now()
+					g.needsRedraw = true
+				} else if !g.clickScreenshotMenu(mx, my) {
 					if !g.screenshotMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 						g.showShotMenu = false
 						g.noColor = false
@@ -184,22 +198,51 @@ func (g *Game) Update() error {
 				}
 			}
 		} else if justPressed && g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.showShotMenu = true
-			g.noColor = g.ssNoColor
+			if g.showShotMenu {
+				if time.Since(g.lastShotClick) >= MenuToggleDelay {
+					g.showShotMenu = false
+					g.noColor = false
+				}
+			} else {
+				g.showShotMenu = true
+				g.noColor = g.ssNoColor
+			}
+			g.lastShotClick = time.Now()
 			g.needsRedraw = true
 		} else if justPressed && g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.showOptions = true
+			if g.showOptions {
+				if time.Since(g.lastOptionsClick) >= MenuToggleDelay {
+					g.showOptions = false
+				}
+			} else {
+				g.showOptions = true
+			}
+			g.lastOptionsClick = time.Now()
 			g.needsRedraw = true
 		} else if justPressed && g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.showAstMenu = true
+			if g.showAstMenu {
+				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
+					g.showAstMenu = false
+				}
+			} else {
+				g.showAstMenu = true
+			}
+			g.lastAsteroidClick = time.Now()
 			g.needsRedraw = true
 		} else if justPressed && g.clickLegend(mx, my) {
 			// handled in clickLegend
 		} else if justPressed && g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			g.camX = oldX
-			g.camY = oldY
-			g.dragging = false
-			g.showGeyserList = true
+			if g.showGeyserList {
+				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
+					g.showGeyserList = false
+				}
+			} else {
+				g.camX = oldX
+				g.camY = oldY
+				g.dragging = false
+				g.showGeyserList = true
+			}
+			g.lastGeyserClick = time.Now()
 			g.needsRedraw = true
 		} else if justPressed {
 			if info, ix, iy, icon, found := g.itemAt(mx, my); found {

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -55,7 +55,13 @@ func (g *Game) handleGeyserListInput() bool {
 	mx, my := ebiten.CursorPosition()
 	if mx >= 0 && mx < g.width && my >= 0 && my < g.height {
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
-			if g.geyserCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+			if g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
+					g.showGeyserList = false
+				}
+				g.lastGeyserClick = time.Now()
+				g.needsRedraw = true
+			} else if g.geyserCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 				g.showGeyserList = false
 				g.needsRedraw = true
 			}
@@ -64,7 +70,13 @@ func (g *Game) handleGeyserListInput() bool {
 	for _, id := range inpututil.AppendJustPressedTouchIDs(nil) {
 		x, y := ebiten.TouchPosition(id)
 		if x >= 0 && x < g.width && y >= 0 && y < g.height {
-			if g.geyserCloseRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
+			if g.geyserRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
+				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
+					g.showGeyserList = false
+				}
+				g.lastGeyserClick = time.Now()
+				g.needsRedraw = true
+			} else if g.geyserCloseRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
 				g.showGeyserList = false
 				g.needsRedraw = true
 			}
@@ -84,7 +96,13 @@ func (g *Game) handleAsteroidMenuInput() bool {
 	mx, my := ebiten.CursorPosition()
 	if mx >= 0 && mx < g.width && my >= 0 && my < g.height {
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
-			if !g.clickAsteroidMenu(mx, my) {
+			if g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
+					g.showAstMenu = false
+				}
+				g.lastAsteroidClick = time.Now()
+				g.needsRedraw = true
+			} else if !g.clickAsteroidMenu(mx, my) {
 				if !g.asteroidMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 					g.showAstMenu = false
 					g.needsRedraw = true
@@ -95,7 +113,13 @@ func (g *Game) handleAsteroidMenuInput() bool {
 	for _, id := range inpututil.AppendJustPressedTouchIDs(nil) {
 		x, y := ebiten.TouchPosition(id)
 		if x >= 0 && x < g.width && y >= 0 && y < g.height {
-			if !g.clickAsteroidMenu(x, y) {
+			if g.asteroidInfoRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
+				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
+					g.showAstMenu = false
+				}
+				g.lastAsteroidClick = time.Now()
+				g.needsRedraw = true
+			} else if !g.clickAsteroidMenu(x, y) {
 				if !g.asteroidMenuRect().Overlaps(image.Rect(x, y, x+1, y+1)) && !g.asteroidInfoRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
 					g.showAstMenu = false
 					g.needsRedraw = true


### PR DESCRIPTION
## Summary
- add `MenuToggleDelay` constant
- store last click times in `Game`
- toggle menus when clicking icons again if enough time passes
- draw single background block behind seed and asteroid labels

## Testing
- `go test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_686b2eddc618832ab4038c15b44f44dc