### PR TITLE
Add scrollbar and panel padding

### DIFF
--- a/const.go
+++ b/const.go
@@ -49,8 +49,10 @@ const (
 	ScreenshotBWLabel     = "Black and White"
 	ScreenshotCancelLabel = "Cancel"
 	GeyserRowSpacing      = 60
-	OptionsMenuTitle      = "Options:"
-	AsteroidMenuTitle     = "Asteroids:"
+	// ScrollBarWidth specifies the width of pseudo scroll bars.
+	ScrollBarWidth    = 6
+	OptionsMenuTitle  = "Options:"
+	AsteroidMenuTitle = "Asteroids:"
 
 	// BiomeTextureScale controls the repetition of biome textures.
 	// Smaller values result in more repetitions.

--- a/const.go
+++ b/const.go
@@ -109,4 +109,6 @@ var (
 	legendBGColor       = color.RGBA{0, 0, 0, 77}
 	overlayColor        = color.RGBA{0, 0, 0, 180}
 	backgroundColor     = color.RGBA{30, 30, 30, 255}
+	scrollBarColor      = color.RGBA{0, 128, 255, 255}
+	scrollBarTrackColor = color.RGBA{200, 200, 200, 255}
 )

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -173,16 +173,20 @@ func helpMenuSize() (int, int) {
 func (g *Game) helpMenuRect() image.Rectangle {
 	w, h := helpMenuSize()
 	r := g.helpRect()
+	pad := uiScaled(2)
 	x := r.Max.X - w
-	if x < 0 {
-		x = 0
+	if x < pad {
+		x = pad
 	}
-	if x+w > g.width {
-		x = g.width - w
+	if x+w > g.width-pad {
+		x = g.width - w - pad
 	}
 	y := r.Min.Y - h
-	if y < 0 {
-		y = 0
+	if y < pad {
+		y = pad
+	}
+	if y+h > g.height-pad {
+		y = g.height - h - pad
 	}
 	return image.Rect(x, y, x+w, y+h)
 }

--- a/legend.go
+++ b/legend.go
@@ -185,6 +185,15 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 		}
 		y += rowHeights[r] + spacing
 	}
+
+	if max := g.maxGeyserScroll(); max > 0 {
+		barW := uiScaled(ScrollBarWidth)
+		barX := g.width - barW - uiScaled(2)
+		h := float64(g.height)
+		barH := h * h / (h + max)
+		barY := (g.geyserScroll / max) * (h - barH)
+		vector.DrawFilledRect(dst, float32(barX), float32(barY), float32(barW), float32(barH), overlayColor, false)
+	}
 }
 
 func (g *Game) maxGeyserScroll() float64 {

--- a/legend.go
+++ b/legend.go
@@ -192,7 +192,14 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 		h := float64(g.height)
 		barH := h * h / (h + max)
 		barY := (g.geyserScroll / max) * (h - barH)
-		vector.DrawFilledRect(dst, float32(barX), float32(barY), float32(barW), float32(barH), overlayColor, false)
+		left := barX - uiScaled(1)
+		right := barX + barW + uiScaled(1)
+		vector.StrokeLine(dst, float32(left), 0, float32(left), float32(g.height), 1, scrollBarTrackColor, true)
+		vector.StrokeLine(dst, float32(right), 0, float32(right), float32(g.height), 1, scrollBarTrackColor, true)
+		vector.DrawFilledRect(dst, float32(barX), float32(barY), float32(barW), float32(barH), scrollBarColor, false)
+		r := float32(barW) / 2
+		vector.DrawFilledCircle(dst, float32(barX)+r, float32(barY), r, scrollBarColor, true)
+		vector.DrawFilledCircle(dst, float32(barX)+r, float32(barY)+float32(barH), r, scrollBarColor, true)
 	}
 }
 

--- a/options_menu.go
+++ b/options_menu.go
@@ -46,13 +46,20 @@ func (g *Game) optionsMenuSize() (int, int) {
 
 func (g *Game) optionsMenuRect() image.Rectangle {
 	w, h := g.optionsMenuSize()
+	pad := uiScaled(2)
 	x := g.optionsRect().Min.X - w - uiScaled(10)
-	if x < 0 {
-		x = 0
+	if x < pad {
+		x = pad
+	}
+	if x+w > g.width-pad {
+		x = g.width - w - pad
 	}
 	y := g.optionsRect().Min.Y - h
-	if y < 0 {
-		y = 0
+	if y < pad {
+		y = pad
+	}
+	if y+h > g.height-pad {
+		y = g.height - h - pad
 	}
 	return image.Rect(x, y, x+w, y+h)
 }

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -39,16 +39,20 @@ func (g *Game) screenshotMenuSize() (int, int) {
 
 func (g *Game) screenshotMenuRect() image.Rectangle {
 	w, h := g.screenshotMenuSize()
+	pad := uiScaled(2)
 	x := g.screenshotRect().Min.X - w - uiScaled(10)
-	if x < 0 {
-		x = 0
+	if x < pad {
+		x = pad
+	}
+	if x+w > g.width-pad {
+		x = g.width - w - pad
 	}
 	y := g.screenshotRect().Min.Y - h
-	if y < 0 {
-		y = 0
+	if y < pad {
+		y = pad
 	}
-	if y+h > g.height {
-		y = g.height - h
+	if y+h > g.height-pad {
+		y = g.height - h - pad
 	}
 	return image.Rect(x, y, x+w, y+h)
 }


### PR DESCRIPTION
## Summary
- add `ScrollBarWidth` constant
- draw a scrollbar for the geyser list when it overflows
- keep help, screenshot and options menus slightly inset from screen edges

## Testing
- `go test ./...` *(fails: `X11/extensions/Xrandr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b30085258832a994f2b553d5da3f6