### PR TITLE
Fix options menu toggle and close other menus on open

### DIFF
--- a/game_helpers.go
+++ b/game_helpers.go
@@ -329,6 +329,15 @@ func abs(a int) int {
 	return a
 }
 
+func (g *Game) closeMenus() {
+	g.showShotMenu = false
+	g.showAstMenu = false
+	g.showOptions = false
+	g.showGeyserList = false
+	g.showHelp = false
+	g.noColor = false
+}
+
 func (g *Game) startIconLoader(names []string) {
 	for _, name := range names {
 		img, _ := loadImageFile(name)

--- a/touch_input.go
+++ b/touch_input.go
@@ -174,35 +174,52 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					g.needsRedraw = true
 				}
 			} else if g.showShotMenu {
-				if !g.clickScreenshotMenu(mx, my) {
+				if g.screenshotRect().Overlaps(pt) {
+					g.showShotMenu = false
+					g.noColor = false
+					g.needsRedraw = true
+				} else if !g.clickScreenshotMenu(mx, my) {
 					if !g.screenshotMenuRect().Overlaps(pt) && !g.screenshotRect().Overlaps(pt) {
 						g.showShotMenu = false
 						g.needsRedraw = true
 					}
 				}
 			} else if g.showOptions {
-				if !g.clickOptionsMenu(mx, my) {
+				if g.optionsRect().Overlaps(pt) {
+					g.showOptions = false
+					g.needsRedraw = true
+				} else if !g.clickOptionsMenu(mx, my) {
 					if !g.optionsMenuRect().Overlaps(pt) && !g.optionsRect().Overlaps(pt) {
 						g.showOptions = false
 						g.needsRedraw = true
 					}
 				}
 			} else if g.screenshotRect().Overlaps(pt) {
+				g.closeMenus()
 				g.showShotMenu = true
+				g.noColor = g.ssNoColor
 				g.needsRedraw = true
 			} else if g.optionsRect().Overlaps(pt) {
+				g.closeMenus()
 				g.showOptions = true
 				g.needsRedraw = true
 			} else if g.asteroidInfoRect().Overlaps(pt) {
+				g.closeMenus()
 				g.showAstMenu = true
 				g.needsRedraw = true
 			} else if g.helpRect().Overlaps(pt) {
-				g.showHelp = !g.showHelp
+				if g.showHelp {
+					g.showHelp = false
+				} else {
+					g.closeMenus()
+					g.showHelp = true
+				}
 				g.needsRedraw = true
 			} else if g.showHelp && g.helpCloseRect().Overlaps(pt) {
 				g.showHelp = false
 				g.needsRedraw = true
 			} else if g.geyserRect().Overlaps(pt) {
+				g.closeMenus()
 				g.camX = oldX
 				g.camY = oldY
 				g.dragging = false

--- a/update.go
+++ b/update.go
@@ -190,7 +190,13 @@ func (g *Game) Update() error {
 			}
 		} else if g.showOptions {
 			if justPressed {
-				if !g.clickOptionsMenu(mx, my) {
+				if g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+					if time.Since(g.lastOptionsClick) >= MenuToggleDelay {
+						g.showOptions = false
+					}
+					g.lastOptionsClick = time.Now()
+					g.needsRedraw = true
+				} else if !g.clickOptionsMenu(mx, my) {
 					if !g.optionsMenuRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) && !g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 						g.showOptions = false
 						g.needsRedraw = true
@@ -204,6 +210,7 @@ func (g *Game) Update() error {
 					g.noColor = false
 				}
 			} else {
+				g.closeMenus()
 				g.showShotMenu = true
 				g.noColor = g.ssNoColor
 			}
@@ -215,6 +222,7 @@ func (g *Game) Update() error {
 					g.showOptions = false
 				}
 			} else {
+				g.closeMenus()
 				g.showOptions = true
 			}
 			g.lastOptionsClick = time.Now()
@@ -225,6 +233,7 @@ func (g *Game) Update() error {
 					g.showAstMenu = false
 				}
 			} else {
+				g.closeMenus()
 				g.showAstMenu = true
 			}
 			g.lastAsteroidClick = time.Now()
@@ -237,6 +246,7 @@ func (g *Game) Update() error {
 					g.showGeyserList = false
 				}
 			} else {
+				g.closeMenus()
 				g.camX = oldX
 				g.camY = oldY
 				g.dragging = false


### PR DESCRIPTION
## Summary
- add `closeMenus` helper to reset all menu states
- toggle options menu when clicking the gear icon again
- ensure opening any bottom icon closes other menus
- update touch handling for the same behaviour

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b319cf3e0832aa4d99befddac607d