### PR TITLE
Fix toggling and click priority for bottom icons

### DIFF
--- a/legend.go
+++ b/legend.go
@@ -366,6 +366,9 @@ func (g *Game) clickLegend(mx, my int) bool {
 	if !g.showLegend {
 		return false
 	}
+	if g.bottomTrayRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
+		return false
+	}
 	handled := false
 	if g.legend != nil && len(g.legendBiomes) > 0 {
 		w := g.legend.Bounds().Dx()

--- a/update.go
+++ b/update.go
@@ -159,13 +159,7 @@ func (g *Game) Update() error {
 		}
 		g.lastMouseX, g.lastMouseY = mx, my
 		if justPressed && g.helpRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-			if g.showHelp {
-				if time.Since(g.lastHelpClick) >= MenuToggleDelay {
-					g.showHelp = false
-				}
-			} else {
-				g.showHelp = true
-			}
+			g.showHelp = !g.showHelp
 			g.lastHelpClick = time.Now()
 			g.needsRedraw = true
 		} else if g.showHelp && justPressed && g.helpCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
@@ -174,10 +168,8 @@ func (g *Game) Update() error {
 		} else if g.showShotMenu {
 			if justPressed {
 				if g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-					if time.Since(g.lastShotClick) >= MenuToggleDelay {
-						g.showShotMenu = false
-						g.noColor = false
-					}
+					g.showShotMenu = false
+					g.noColor = false
 					g.lastShotClick = time.Now()
 					g.needsRedraw = true
 				} else if !g.clickScreenshotMenu(mx, my) {
@@ -191,9 +183,7 @@ func (g *Game) Update() error {
 		} else if g.showOptions {
 			if justPressed {
 				if g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-					if time.Since(g.lastOptionsClick) >= MenuToggleDelay {
-						g.showOptions = false
-					}
+					g.showOptions = false
 					g.lastOptionsClick = time.Now()
 					g.needsRedraw = true
 				} else if !g.clickOptionsMenu(mx, my) {
@@ -205,10 +195,8 @@ func (g *Game) Update() error {
 			}
 		} else if justPressed && g.screenshotRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			if g.showShotMenu {
-				if time.Since(g.lastShotClick) >= MenuToggleDelay {
-					g.showShotMenu = false
-					g.noColor = false
-				}
+				g.showShotMenu = false
+				g.noColor = false
 			} else {
 				g.closeMenus()
 				g.showShotMenu = true
@@ -218,9 +206,7 @@ func (g *Game) Update() error {
 			g.needsRedraw = true
 		} else if justPressed && g.optionsRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			if g.showOptions {
-				if time.Since(g.lastOptionsClick) >= MenuToggleDelay {
-					g.showOptions = false
-				}
+				g.showOptions = false
 			} else {
 				g.closeMenus()
 				g.showOptions = true
@@ -229,22 +215,16 @@ func (g *Game) Update() error {
 			g.needsRedraw = true
 		} else if justPressed && g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			if g.showAstMenu {
-				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
-					g.showAstMenu = false
-				}
+				g.showAstMenu = false
 			} else {
 				g.closeMenus()
 				g.showAstMenu = true
 			}
 			g.lastAsteroidClick = time.Now()
 			g.needsRedraw = true
-		} else if justPressed && g.clickLegend(mx, my) {
-			// handled in clickLegend
 		} else if justPressed && g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
 			if g.showGeyserList {
-				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
-					g.showGeyserList = false
-				}
+				g.showGeyserList = false
 			} else {
 				g.closeMenus()
 				g.camX = oldX
@@ -254,6 +234,8 @@ func (g *Game) Update() error {
 			}
 			g.lastGeyserClick = time.Now()
 			g.needsRedraw = true
+		} else if justPressed && g.clickLegend(mx, my) {
+			// handled in clickLegend
 		} else if justPressed {
 			if info, ix, iy, icon, found := g.itemAt(mx, my); found {
 				g.camX += float64(g.width/2 - ix)

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -56,9 +56,7 @@ func (g *Game) handleGeyserListInput() bool {
 	if mx >= 0 && mx < g.width && my >= 0 && my < g.height {
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 			if g.geyserRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
-					g.showGeyserList = false
-				}
+				g.showGeyserList = false
 				g.lastGeyserClick = time.Now()
 				g.needsRedraw = true
 			} else if g.geyserCloseRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
@@ -71,9 +69,7 @@ func (g *Game) handleGeyserListInput() bool {
 		x, y := ebiten.TouchPosition(id)
 		if x >= 0 && x < g.width && y >= 0 && y < g.height {
 			if g.geyserRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
-				if time.Since(g.lastGeyserClick) >= MenuToggleDelay {
-					g.showGeyserList = false
-				}
+				g.showGeyserList = false
 				g.lastGeyserClick = time.Now()
 				g.needsRedraw = true
 			} else if g.geyserCloseRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
@@ -97,9 +93,7 @@ func (g *Game) handleAsteroidMenuInput() bool {
 	if mx >= 0 && mx < g.width && my >= 0 && my < g.height {
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 			if g.asteroidInfoRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {
-				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
-					g.showAstMenu = false
-				}
+				g.showAstMenu = false
 				g.lastAsteroidClick = time.Now()
 				g.needsRedraw = true
 			} else if !g.clickAsteroidMenu(mx, my) {
@@ -114,9 +108,7 @@ func (g *Game) handleAsteroidMenuInput() bool {
 		x, y := ebiten.TouchPosition(id)
 		if x >= 0 && x < g.width && y >= 0 && y < g.height {
 			if g.asteroidInfoRect().Overlaps(image.Rect(x, y, x+1, y+1)) {
-				if time.Since(g.lastAsteroidClick) >= MenuToggleDelay {
-					g.showAstMenu = false
-				}
+				g.showAstMenu = false
 				g.lastAsteroidClick = time.Now()
 				g.needsRedraw = true
 			} else if !g.clickAsteroidMenu(x, y) {


### PR DESCRIPTION
## Summary
- fix icon panels toggling logic to close immediately
- give bottom icon tray priority over item legend clicks
- reorder geyser and legend checks

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b33609dc0832ab363d2a10880cb76