### PR TITLE
Avoid intermediate geyser row images

### DIFF
--- a/const.go
+++ b/const.go
@@ -48,7 +48,6 @@ const (
 	ScreenshotSavedLabel  = "Saved!"
 	ScreenshotBWLabel     = "Black and White"
 	ScreenshotCancelLabel = "Cancel"
-	GeyserRowSpacing      = 60
 	// ScrollBarWidth specifies the width of pseudo scroll bars.
 	ScrollBarWidth    = 6
 	OptionsMenuTitle  = "Options:"

--- a/drawing.go
+++ b/drawing.go
@@ -84,23 +84,18 @@ func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x
 		iconH = uiScaled(InfoIconSize)
 	}
 	gap := uiScaled(4)
-	w := txtW + iconW + gap
 	h := txtH
 	if iconH > txtH {
 		h = iconH
 	}
-	img := ebiten.NewImage(w, h)
 	if icon != nil {
 		opIcon := &ebiten.DrawImageOptions{Filter: g.filterMode()}
 		sc := float64(uiScaled(InfoIconSize)) / math.Max(float64(icon.Bounds().Dx()), float64(icon.Bounds().Dy()))
 		opIcon.GeoM.Scale(sc, sc)
-		opIcon.GeoM.Translate(0, float64(h-iconH)/2)
-		img.DrawImage(icon, opIcon)
+		opIcon.GeoM.Translate(float64(x), float64(y+(h-iconH)/2))
+		dst.DrawImage(icon, opIcon)
 	}
-	drawText(img, text, iconW+gap, (h-txtH)/2, false)
-	op := &ebiten.DrawImageOptions{}
-	op.GeoM.Translate(float64(x), float64(y))
-	dst.DrawImage(img, op)
+	drawText(dst, text, x+iconW+gap, y+(h-txtH)/2, false)
 }
 
 func infoPanelSize(text string, icon *ebiten.Image) (int, int) {

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -39,6 +39,7 @@ type Game struct {
 	legendColors      []color.RGBA
 	legendImage       *ebiten.Image
 	legendBiomes      []string
+	geyserItems       []geyserListItem
 	hoverBiome        int
 	hoverItem         int
 	selectedBiome     int
@@ -120,6 +121,13 @@ type touchPoint struct {
 type loadedIcon struct {
 	name string
 	img  *ebiten.Image
+}
+
+type geyserListItem struct {
+	text string
+	icon *ebiten.Image
+	w    int
+	h    int
 }
 
 func (g *Game) uiScale() float64 { return uiScale }

--- a/legend.go
+++ b/legend.go
@@ -85,6 +85,7 @@ func (g *Game) initObjectLegend() {
 func (g *Game) invalidateLegends() {
 	g.legend = nil
 	g.legendImage = nil
+	g.geyserItems = nil
 }
 
 func (g *Game) drawNumberLegend(dst *ebiten.Image) {
@@ -132,20 +133,11 @@ func (g *Game) drawNumberLegend(dst *ebiten.Image) {
 	}
 }
 
-func (g *Game) drawGeyserList(dst *ebiten.Image) {
-	vector.DrawFilledRect(dst, 0, 0, float32(g.width), float32(g.height), color.RGBA{0, 0, 0, 255}, false)
-	cr := g.geyserCloseRect()
-	drawCloseButton(dst, cr)
-
-	spacing := 10
-	type item struct {
-		text string
-		icon *ebiten.Image
-		w    int
-		h    int
+func (g *Game) buildGeyserItems() {
+	if g.geyserItems != nil && len(g.geyserItems) == len(g.geysers) {
+		return
 	}
-	items := make([]item, len(g.geysers))
-	maxW := 0
+	g.geyserItems = make([]geyserListItem, len(g.geysers))
 	for i, gy := range g.geysers {
 		ic := (*ebiten.Image)(nil)
 		if n := iconForGeyser(gy.ID); n != "" {
@@ -153,10 +145,22 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 		}
 		txt := displayGeyser(gy.ID) + "\n" + formatGeyserInfo(gy)
 		w, h := infoRowSize(txt, ic)
-		if w > maxW {
-			maxW = w
+		g.geyserItems[i] = geyserListItem{text: txt, icon: ic, w: w, h: h}
+	}
+}
+
+func (g *Game) drawGeyserList(dst *ebiten.Image) {
+	vector.DrawFilledRect(dst, 0, 0, float32(g.width), float32(g.height), color.RGBA{0, 0, 0, 255}, false)
+	cr := g.geyserCloseRect()
+	drawCloseButton(dst, cr)
+
+	spacing := uiScaled(10)
+	g.buildGeyserItems()
+	maxW := 0
+	for _, it := range g.geyserItems {
+		if it.w > maxW {
+			maxW = it.w
 		}
-		items[i] = item{text: txt, icon: ic, w: w, h: h}
 	}
 	cols := 1
 	if maxW+spacing > 0 {
@@ -165,9 +169,9 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 			cols = 1
 		}
 	}
-	rows := (len(items) + cols - 1) / cols
+	rows := (len(g.geyserItems) + cols - 1) / cols
 	rowHeights := make([]int, rows)
-	for i, it := range items {
+	for i, it := range g.geyserItems {
 		r := i / cols
 		if it.h > rowHeights[r] {
 			rowHeights[r] = it.h
@@ -176,14 +180,17 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 	y := spacing - int(g.geyserScroll)
 	idx := 0
 	for r := 0; r < rows; r++ {
+		rowH := rowHeights[r]
 		x := spacing
-		for c := 0; c < cols && idx < len(items); c++ {
-			it := items[idx]
-			g.drawInfoRow(dst, it.text, it.icon, x, y)
+		for c := 0; c < cols && idx < len(g.geyserItems); c++ {
+			it := g.geyserItems[idx]
+			if y+rowH > 0 && y < g.height && x+it.w > 0 && x < g.width {
+				g.drawInfoRow(dst, it.text, it.icon, x, y)
+			}
 			x += maxW + spacing
 			idx++
 		}
-		y += rowHeights[r] + spacing
+		y += rowH + spacing
 	}
 
 	if max := g.maxGeyserScroll(); max > 0 {
@@ -204,24 +211,13 @@ func (g *Game) drawGeyserList(dst *ebiten.Image) {
 }
 
 func (g *Game) maxGeyserScroll() float64 {
-	spacing := 10
-	type item struct {
-		w int
-		h int
-	}
-	items := make([]item, len(g.geysers))
+	spacing := uiScaled(10)
+	g.buildGeyserItems()
 	maxW := 0
-	for i, gy := range g.geysers {
-		ic := (*ebiten.Image)(nil)
-		if n := iconForGeyser(gy.ID); n != "" {
-			ic = g.icons[n]
+	for _, it := range g.geyserItems {
+		if it.w > maxW {
+			maxW = it.w
 		}
-		txt := displayGeyser(gy.ID) + "\n" + formatGeyserInfo(gy)
-		w, h := infoRowSize(txt, ic)
-		if w > maxW {
-			maxW = w
-		}
-		items[i] = item{w: w, h: h}
 	}
 	cols := 1
 	if maxW+spacing > 0 {
@@ -230,12 +226,12 @@ func (g *Game) maxGeyserScroll() float64 {
 			cols = 1
 		}
 	}
-	rows := (len(items) + cols - 1) / cols
+	rows := (len(g.geyserItems) + cols - 1) / cols
 	if rows == 0 {
 		return 0
 	}
 	rowHeights := make([]int, rows)
-	for i, it := range items {
+	for i, it := range g.geyserItems {
 		r := i / cols
 		if it.h > rowHeights[r] {
 			rowHeights[r] = it.h
@@ -245,11 +241,12 @@ func (g *Game) maxGeyserScroll() float64 {
 	for _, h := range rowHeights {
 		total += h + spacing
 	}
-	max := total - rowHeights[rows-1] - spacing
+	extra := rowHeights[rows-1] + spacing
+	max := float64(total - g.height + extra)
 	if max < 0 {
 		max = 0
 	}
-	return float64(max)
+	return max
 }
 
 func (g *Game) adjustGeyserScroll(delta float64) {


### PR DESCRIPTION
## Summary
- cache geyser list items for reuse
- draw geyser list rows directly onto the screen
- rebuild caches when fonts change

## Testing
- `go test ./...` *(fails to build: cannot find X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_686b3dc12644832a9e65a22359a51215