### PR TITLE
Update screenshot scaling and grayscale legend behavior

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -230,7 +230,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 			drawText(screen, label, x, seedBaseline(), true)
 		}
 
-		if g.showLegend {
+		if g.showLegend && !g.noColor {
 			if g.legend == nil {
 				g.legend, g.legendBiomes = buildLegendImage(g.biomes)
 			}

--- a/fonts.go
+++ b/fonts.go
@@ -11,8 +11,7 @@ import (
 var notoTTF []byte
 
 const (
-	baseFontSize       = 11.0
-	screenshotFontSize = 32.0
+	baseFontSize = 11.0
 )
 
 var (

--- a/legend.go
+++ b/legend.go
@@ -287,7 +287,7 @@ func (g *Game) maxItemScroll() float64 {
 }
 
 func (g *Game) itemPanelVisible() bool {
-	return g.showLegend && g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	return g.showLegend && g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
 }
 
 func (g *Game) updateHover(mx, my int) {
@@ -295,7 +295,7 @@ func (g *Game) updateHover(mx, my int) {
 	prevItem := g.hoverItem
 	g.hoverBiome = -1
 	g.hoverItem = -1
-	if !g.showLegend {
+	if !g.showLegend || g.noColor {
 		if prevBiome != -1 || prevItem != -1 {
 			g.needsRedraw = true
 		}
@@ -376,7 +376,7 @@ func (g *Game) updateIconHover(mx, my int) {
 }
 
 func (g *Game) clickLegend(mx, my int) bool {
-	if !g.showLegend {
+	if !g.showLegend || g.noColor {
 		return false
 	}
 	if g.bottomTrayRect().Overlaps(image.Rect(mx, my, mx+1, my+1)) {

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -178,8 +178,8 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	g.camX = 0
 	g.camY = 0
 	g.screenshotMode = true
-	oldSize := fontSize
-	setFontSize(screenshotFontSize)
+	oldScale := uiScale
+	setUIScale(4.0)
 	img := ebiten.NewImage(w, h)
 	g.needsRedraw = true
 	g.Draw(img)
@@ -187,7 +187,7 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	pix := make([]byte, 4*b.Dx()*b.Dy())
 	img.ReadPixels(pix)
 	rgba := &image.RGBA{Pix: pix, Stride: 4 * b.Dx(), Rect: b}
-	setFontSize(oldSize)
+	setUIScale(oldScale)
 	g.screenshotMode = false
 	g.width = ow
 	g.height = oh

--- a/touch_input.go
+++ b/touch_input.go
@@ -34,13 +34,13 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 				g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 				g.touchUI = true
 			} else {
-				if g.legend != nil && g.showLegend {
+				if g.legend != nil && g.showLegend && !g.noColor {
 					if g.biomeLegendRect().Overlaps(pt) {
 						g.touchUI = true
 					}
 				}
 				useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-				if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
+				if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
 					if g.itemLegendRect().Overlaps(pt) {
 						g.touchUI = true
 					}
@@ -62,7 +62,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 				if g.showGeyserList {
 					g.adjustGeyserScroll(-float64(dy))
 				} else {
-					if g.legend != nil && g.showLegend {
+					if g.legend != nil && g.showLegend && !g.noColor {
 						pt := image.Rect(g.touchStartX, g.touchStartY, g.touchStartX+1, g.touchStartY+1)
 						if g.biomeLegendRect().Overlaps(pt) {
 							g.biomeScroll -= float64(dy)
@@ -76,7 +76,7 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 						}
 					}
 					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-					if useNumbers && g.legendImage != nil && g.showLegend {
+					if useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
 						pt := image.Rect(g.touchStartX, g.touchStartY, g.touchStartX+1, g.touchStartY+1)
 						if g.itemLegendRect().Overlaps(pt) {
 							g.itemScroll -= float64(dy)
@@ -112,14 +112,14 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 					g.geyserRect().Overlaps(pt) || g.optionsRect().Overlaps(pt) {
 					g.touchUI = true
 				} else {
-					if g.legend != nil && g.showLegend {
+					if g.legend != nil && g.showLegend && !g.noColor {
 						pt := image.Rect(x, y, x+1, y+1)
 						if g.biomeLegendRect().Overlaps(pt) {
 							g.touchUI = true
 						}
 					}
 					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-					if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
+					if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
 						pt := image.Rect(x, y, x+1, y+1)
 						if g.itemLegendRect().Overlaps(pt) {
 							g.touchUI = true

--- a/update.go
+++ b/update.go
@@ -90,7 +90,7 @@ func (g *Game) Update() error {
 		} else {
 			handled := false
 			useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-			if g.legend != nil && g.showLegend {
+			if g.legend != nil && g.showLegend && !g.noColor {
 				lw := g.legend.Bounds().Dx()
 				lh := g.legend.Bounds().Dy()
 				if lh > g.height && mxTmp >= 0 && mxTmp < lw {
@@ -106,7 +106,7 @@ func (g *Game) Update() error {
 					handled = true
 				}
 			}
-			if !handled && useNumbers && g.legendImage != nil && g.showLegend {
+			if !handled && useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
 				lw := g.legendImage.Bounds().Dx()
 				lh := g.legendImage.Bounds().Dy()
 				x0 := g.width - lw - 12


### PR DESCRIPTION
## Summary
- remove screenshot-specific font size constant
- scale UI to 4x when capturing screenshots
- hide biome legends when rendering in grayscale

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b46d7782c832aa72df17992acccb0