### PR TITLE
Add grayscale screenshot save

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ the environments are:
 Click the camera icon to open the screenshot menu. Choose a quality level
 (2K–8K) and the current view is written to a BMP named after the seed.
 After clicking **Save Screenshot** the button briefly shows *Taking Screenshot...*
-with a red outline before the menu closes automatically.
+with a red outline before the menu closes automatically. When the **Black and
+White** toggle is enabled the screenshot is saved as an 8-bit grayscale image.
 You can also generate a screenshot non-interactively:
 
 ```bash


### PR DESCRIPTION
## Summary
- convert captured images to grayscale when black-and-white screenshot mode is enabled
- document grayscale screenshot behavior in README

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b494aef88832a87abfe1d6039a065