### PR TITLE
Hide numbers in screenshot or monochrome

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -53,7 +53,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		labels := []label{}
 		var highlightGeysers []Geyser
 		var highlightPOIs []PointOfInterest
-		useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && g.showItemNames
+		useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor && g.showItemNames
 		if g.legendMap == nil {
 			g.initObjectLegend()
 		}
@@ -244,7 +244,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				w := math.Round(float64(g.legend.Bounds().Dx()))
 				vector.StrokeRect(screen, 0.5, float32(y0)-4, float32(w)-1, float32(h)-1, 2, highlightColor, false)
 			}
-			if useNumbers && !g.screenshotMode {
+			if useNumbers {
 				g.drawNumberLegend(screen)
 			}
 		}

--- a/legend.go
+++ b/legend.go
@@ -322,7 +322,7 @@ func (g *Game) updateHover(mx, my int) {
 			}
 		}
 	}
-	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
 	if useNumbers && g.legendImage != nil {
 		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12
@@ -404,7 +404,7 @@ func (g *Game) clickLegend(mx, my int) bool {
 			}
 		}
 	}
-	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
+	useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
 	if useNumbers && g.legendImage != nil {
 		w := g.legendImage.Bounds().Dx()
 		x0 := g.width - w - 12

--- a/touch_input.go
+++ b/touch_input.go
@@ -39,8 +39,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 						g.touchUI = true
 					}
 				}
-				useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-				if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
+				useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
+				if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
 					if g.itemLegendRect().Overlaps(pt) {
 						g.touchUI = true
 					}
@@ -75,8 +75,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 							g.updateHover(x, y)
 						}
 					}
-					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-					if useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
+					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
+					if useNumbers && g.legendImage != nil && g.showLegend {
 						pt := image.Rect(g.touchStartX, g.touchStartY, g.touchStartX+1, g.touchStartY+1)
 						if g.itemLegendRect().Overlaps(pt) {
 							g.itemScroll -= float64(dy)
@@ -118,8 +118,8 @@ func (g *Game) handleTouchGestures(oldX, oldY float64) {
 							g.touchUI = true
 						}
 					}
-					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
-					if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend && !g.noColor {
+					useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
+					if !g.touchUI && useNumbers && g.legendImage != nil && g.showLegend {
 						pt := image.Rect(x, y, x+1, y+1)
 						if g.itemLegendRect().Overlaps(pt) {
 							g.touchUI = true

--- a/update.go
+++ b/update.go
@@ -89,7 +89,7 @@ func (g *Game) Update() error {
 			g.adjustGeyserScroll(-float64(wheelY) * 10)
 		} else {
 			handled := false
-			useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode
+			useNumbers := g.useNumbers && g.zoom < LegendZoomThreshold && !g.screenshotMode && !g.noColor
 			if g.legend != nil && g.showLegend && !g.noColor {
 				lw := g.legend.Bounds().Dx()
 				lh := g.legend.Bounds().Dy()


### PR DESCRIPTION
## Summary
- avoid showing numeric item labels when taking screenshots or using black/white mode

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b4ae5ef88832aab932ee1b0972018