### PR TITLE
Fix grayscale screenshot conversion

### DIFF
--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -208,19 +208,20 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	return rgba
 }
 
-func rgbaToGray(src *image.RGBA) *image.Gray {
-	dst := image.NewGray(src.Bounds())
+func rgbaToGray(src *image.RGBA) *image.RGBA {
 	for y := 0; y < src.Rect.Dy(); y++ {
 		sp := src.Pix[y*src.Stride:]
-		dp := dst.Pix[y*dst.Stride:]
 		for x := 0; x < src.Rect.Dx(); x++ {
 			i := x * 4
 			r := sp[i]
-			gr := sp[i+1]
+			g := sp[i+1]
 			b := sp[i+2]
-			yv := (299*uint16(r) + 587*uint16(gr) + 114*uint16(b) + 500) / 1000
-			dp[x] = uint8(yv)
+			yv := (299*uint16(r) + 587*uint16(g) + 114*uint16(b) + 500) / 1000
+			yb := uint8(yv)
+			sp[i] = yb
+			sp[i+1] = yb
+			sp[i+2] = yb
 		}
 	}
-	return dst
+	return src
 }


### PR DESCRIPTION
## Summary
- optimize `rgbaToGray` by desaturating the pixels in-place
- keep the screenshot output as `*image.RGBA` for `bmp` encoding

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686b4f8a06c0832aa78195c9f9e35159