### PR TITLE
Fix grayscale screenshot output

### DIFF
--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -208,20 +208,19 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	return rgba
 }
 
-func rgbaToGray(src *image.RGBA) *image.RGBA {
+func rgbaToGray(src *image.RGBA) *image.Gray {
+	dst := image.NewGray(src.Bounds())
 	for y := 0; y < src.Rect.Dy(); y++ {
 		sp := src.Pix[y*src.Stride:]
+		dp := dst.Pix[y*dst.Stride:]
 		for x := 0; x < src.Rect.Dx(); x++ {
 			i := x * 4
 			r := sp[i]
 			g := sp[i+1]
 			b := sp[i+2]
 			yv := (299*uint16(r) + 587*uint16(g) + 114*uint16(b) + 500) / 1000
-			yb := uint8(yv)
-			sp[i] = yb
-			sp[i+1] = yb
-			sp[i+2] = yb
+			dp[x] = uint8(yv)
 		}
 	}
-	return src
+	return dst
 }


### PR DESCRIPTION
## Summary
- return `image.Gray` from `rgbaToGray` to ensure 8‑bit grayscale screenshots

## Testing
- `gofmt -w *.go`
- `go test ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_686b505c1038832a9a532d999d24da5c