### PR TITLE
Fix grayscale screenshot output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Click the camera icon to open the screenshot menu. Choose a quality level
 (2K–8K) and the current view is written to a BMP named after the seed.
 After clicking **Save Screenshot** the button briefly shows *Taking Screenshot...*
 with a red outline before the menu closes automatically. When the **Black and
-White** toggle is enabled the screenshot is saved as an 8-bit grayscale image.
+White** toggle is enabled the screenshot is saved in grayscale.
 You can also generate a screenshot non-interactively:
 
 ```bash

--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -208,19 +208,20 @@ func (g *Game) captureScreenshot(w, h int, zoom float64) *image.RGBA {
 	return rgba
 }
 
-func rgbaToGray(src *image.RGBA) *image.Gray {
-	dst := image.NewGray(src.Bounds())
+func rgbaToGray(src *image.RGBA) *image.RGBA {
 	for y := 0; y < src.Rect.Dy(); y++ {
 		sp := src.Pix[y*src.Stride:]
-		dp := dst.Pix[y*dst.Stride:]
 		for x := 0; x < src.Rect.Dx(); x++ {
 			i := x * 4
 			r := sp[i]
 			g := sp[i+1]
 			b := sp[i+2]
 			yv := (299*uint16(r) + 587*uint16(g) + 114*uint16(b) + 500) / 1000
-			dp[x] = uint8(yv)
+			yb := uint8(yv)
+			sp[i] = yb
+			sp[i+1] = yb
+			sp[i+2] = yb
 		}
 	}
-	return dst
+	return src
 }


### PR DESCRIPTION
## Summary
- fix grayscale screenshot output so BMP encoder receives RGBA data
- note grayscale screenshots in README

## Testing
- `go test ./...` *(fails: cannot find X11/extensions/Xrandr.h)*

------
https://chatgpt.com/codex/tasks/task_e_686b52e3b994832a839bd76140e27906