### PR TITLE
Implement grayscale screenshot option

### DIFF
--- a/screenshot_menu.go
+++ b/screenshot_menu.go
@@ -11,6 +11,19 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+func desaturateImage(img *image.RGBA) {
+	const r = 0.299
+	const g = 0.587
+	const b = 0.114
+	pix := img.Pix
+	for i := 0; i < len(pix); i += 4 {
+		gray := uint8(float64(pix[i])*r + float64(pix[i+1])*g + float64(pix[i+2])*b)
+		pix[i] = gray
+		pix[i+1] = gray
+		pix[i+2] = gray
+	}
+}
+
 func (g *Game) screenshotRect() image.Rectangle {
 	size := g.iconSize()
 	x := g.width - size*2 - uiScaled(HelpMargin*2)
@@ -151,10 +164,10 @@ func (g *Game) saveScreenshot() {
 	scale := ScreenshotScales[g.ssQuality]
 	width := int(float64(g.astWidth) * 2 * scale)
 	height := int(float64(g.astHeight) * 2 * scale)
-	oldBW := g.noColor
-	g.noColor = g.ssNoColor
 	img := g.captureScreenshot(width, height, scale)
-	g.noColor = oldBW
+	if g.ssNoColor {
+		desaturateImage(img)
+	}
 	var buf bytes.Buffer
 	_ = bmp.Encode(&buf, img)
 	name := fmt.Sprintf("%s-%s.bmp", g.coord, time.Now().Format("20060102-150405"))


### PR DESCRIPTION
## Summary
- add `desaturateImage` helper for screenshot processing
- when saving a screenshot, always capture in color and optionally desaturate

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b54974948832a807afbd46d6e1721