### PR TITLE
Integrate EUI screenshot menu

### DIFF
--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	eui "EUI/eui"
+
 	"golang.org/x/image/bmp"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -66,6 +68,8 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		cr := g.helpCloseRect()
 		drawCloseButton(screen, cr)
 	}
+
+	eui.Draw(screen)
 
 	g.needsRedraw = false
 	g.lastDraw = time.Now()

--- a/eui_menus.go
+++ b/eui_menus.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	eui "EUI/eui"
+)
+
+func (g *Game) initEUI() {
+	eui.SetUIScale(float32(uiScale))
+
+	w := eui.NewWindow(&eui.WindowData{
+		Title:     ScreenshotMenuTitle,
+		Size:      eui.Point{X: 160, Y: 120},
+		Open:      false,
+		Resizable: false,
+	})
+	flow := &eui.ItemData{ItemType: eui.ITEM_FLOW, Size: w.Size, FlowType: eui.FLOW_VERTICAL}
+	w.AddItem(flow)
+
+	for i, q := range ScreenshotQualities {
+		btn, ev := eui.NewButton(&eui.ItemData{Text: q, Size: eui.Point{X: 140, Y: 20}, FontSize: 8})
+		idx := i
+		ev.Handle = func(ev eui.UIEvent) {
+			if ev.Type == eui.EventClick {
+				g.ssQuality = idx
+			}
+		}
+		flow.AddItem(btn)
+	}
+
+	bwBtn, bwEv := eui.NewButton(&eui.ItemData{Text: ScreenshotBWLabel, Size: eui.Point{X: 140, Y: 20}, FontSize: 8})
+	bwEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			g.ssNoColor = !g.ssNoColor
+			g.noColor = g.ssNoColor
+		}
+	}
+	flow.AddItem(bwBtn)
+
+	saveBtn, saveEv := eui.NewButton(&eui.ItemData{Text: ScreenshotSaveLabel, Size: eui.Point{X: 140, Y: 20}, FontSize: 8})
+	saveEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			if g.ssPending == 0 {
+				g.ssPending = 2
+			}
+		}
+	}
+	flow.AddItem(saveBtn)
+
+	cancelBtn, cancelEv := eui.NewButton(&eui.ItemData{Text: ScreenshotCancelLabel, Size: eui.Point{X: 140, Y: 20}, FontSize: 8})
+	cancelEv.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			g.showShotMenu = false
+			w.Open = false
+		}
+	}
+	flow.AddItem(cancelBtn)
+
+	g.ssWindow = w
+	w.AddWindow(false)
+}

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"time"
 
+	eui "EUI/eui"
+
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/vector"
 )
@@ -104,6 +106,8 @@ type Game struct {
 	lastOptionsClick  time.Time
 	lastGeyserClick   time.Time
 	lastAsteroidClick time.Time
+
+	ssWindow *eui.WindowData
 }
 
 type label struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module oni-view
 go 1.24.3
 
 require (
+	EUI v0.0.0-20250722093719-68ec2eeb3382
 	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/hajimehoshi/ebiten/v2 v2.8.8
 	golang.org/x/image v0.20.0
@@ -12,9 +13,13 @@ require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/go-text/typesetting v0.2.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
+	golang.org/x/time v0.12.0 // indirect
 )
+
+replace EUI => github.com/Distortions81/EUI v0.0.0-20250722093719-68ec2eeb3382

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Distortions81/EUI v0.0.0-20250722093719-68ec2eeb3382 h1:OHquz1Dg3aDoM8jzHDiT/JkF5MzsYg9NYUmb2kWyn+A=
+github.com/Distortions81/EUI v0.0.0-20250722093719-68ec2eeb3382/go.mod h1:pSKmt5YKIbXzGB1EvG/GKIc4YGVM3yU1YWnMv7meYHI=
 github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 h1:Gk1XUEttOk0/hb6Tq3WkmutWa0ZLhNn/6fc6XZpM7tM=
 github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325/go.mod h1:ulhSQcbPioQrallSuIzF8l1NKQoD7xmMZc5NxzibUMY=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
@@ -6,6 +8,10 @@ github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+Gv
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/go-text/typesetting v0.2.0 h1:fbzsgbmk04KiWtE+c3ZD4W2nmCRzBqrqQOvYlwAOdho=
+github.com/go-text/typesetting v0.2.0/go.mod h1:2+owI/sxa73XA581LAzVuEBZ3WEEV2pXeDswCH/3i1I=
+github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66 h1:GUrm65PQPlhFSKjLPGOZNPNxLCybjzjYBzjfoBGaDUY=
+github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0 h1:0DISQM/rseKIJhdF29AkhvdzIULqNIIlXAGWit4ez1Q=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0/go.mod h1:8gLqGatKVu0pwcNCJguW3Igg9WQqVXF0zg/RvrGQWyg=
 github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
@@ -24,3 +30,5 @@ golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=

--- a/layout.go
+++ b/layout.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"math"
+
+	eui "EUI/eui"
 )
 
 func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
-	scale := getHiDPIScale()
-	screenW := int(float64(outsideWidth) * scale)
-	screenH := int(float64(outsideHeight) * scale)
+	screenW, screenH := eui.Layout(outsideWidth, outsideHeight)
 
 	/*
 		if !g.screenshotMode {

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 		selectedBiome:     -1,
 		selectedItem:      -1,
 	}
+	game.initEUI()
 	setHiDPI(game.hidpi)
 	registerFontChange(game.invalidateLegends)
 	loadGameData(game, *coord, asteroidIDVal)

--- a/update.go
+++ b/update.go
@@ -5,12 +5,21 @@ import (
 	"runtime"
 	"time"
 
+	eui "EUI/eui"
+
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
 func (g *Game) Update() error {
 	const panSpeed = PanSpeed
+
+	if err := eui.Update(); err != nil {
+		return err
+	}
+	if g.ssWindow != nil {
+		g.ssWindow.Open = g.showShotMenu
+	}
 
 	g.checkRedrawTriggers()
 	g.processScreenshot()


### PR DESCRIPTION
## Summary
- add EUI dependency with replace directive
- create `initEUI` to build screenshot window using EUI widgets
- hook EUI update/draw into game update/draw
- adapt layout to use `eui.Layout`

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f606990c8832aa6694faae973fe96