### PR TITLE
Code cleanup and lint fixes

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -44,7 +44,7 @@ func assetExists(name string) bool {
 	if err != nil {
 		return false
 	}
-	f.Close()
+	defer func() { _ = f.Close() }()
 	return true
 }
 
@@ -76,7 +76,7 @@ func loadImageFile(name string) (*ebiten.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var src image.Image
 	ext := strings.ToLower(filepath.Ext(name))
 	switch ext {

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -69,19 +69,6 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 
 	g.needsRedraw = false
 	g.lastDraw = time.Now()
-	/*
-		if g.noColor {
-			if g.grayImage == nil || g.grayImage.Bounds().Dx() != g.width || g.grayImage.Bounds().Dy() != g.height {
-				g.grayImage = ebiten.NewImage(g.width, g.height)
-			}
-			g.grayImage.Clear()
-			g.grayImage.DrawImage(screen, nil)
-			screen.Clear()
-			op := &ebiten.DrawImageOptions{}
-			op.ColorM = grayColorM
-			screen.DrawImage(g.grayImage, op)
-		}
-	*/
 }
 
 func (g *Game) captureScreen(screen *ebiten.Image) {
@@ -94,7 +81,7 @@ func (g *Game) captureScreen(screen *ebiten.Image) {
 	img := &image.RGBA{Pix: pixels, Stride: 4 * b.Dx(), Rect: b}
 	if f, err := os.Create(g.screenshotPath); err == nil {
 		_ = bmp.Encode(f, img)
-		f.Close()
+		_ = f.Close()
 	}
 	g.captured = true
 }

--- a/drawing.go
+++ b/drawing.go
@@ -100,23 +100,6 @@ func (g *Game) drawInfoRow(dst *ebiten.Image, text string, icon *ebiten.Image, x
 	drawText(dst, text, x+iconW+gap, y+(h-txtH)/2, false)
 }
 
-func infoPanelSize(text string, icon *ebiten.Image) (int, int) {
-	txtW, txtH := textDimensions(text)
-	iconW, iconH := 0, 0
-	if icon != nil {
-		iconW = uiScaled(InfoIconSize)
-		iconH = uiScaled(InfoIconSize)
-	}
-	gap := uiScaled(4)
-	w := txtW + iconW + gap + uiScaled(8)
-	h := txtH
-	if iconH > txtH {
-		h = iconH
-	}
-	h += uiScaled(8)
-	return w, h
-}
-
 func infoRowSize(text string, icon *ebiten.Image) (int, int) {
 	txtW, txtH := textDimensions(text)
 	iconW, iconH := 0, 0

--- a/fonts.go
+++ b/fonts.go
@@ -45,14 +45,6 @@ func setFontSize(size float64) {
 	}
 }
 
-func increaseFontSize() { setFontSize(fontSize + 3) }
-
-func decreaseFontSize() {
-	if fontSize > 6 {
-		setFontSize(fontSize - 3)
-	}
-}
-
 func registerFontChange(fn func()) {
 	fontChange = append(fontChange, fn)
 }

--- a/game_helpers.go
+++ b/game_helpers.go
@@ -97,7 +97,6 @@ type Game struct {
 
 	noColor   bool
 	ssNoColor bool
-	grayImage *ebiten.Image
 
 	lastHelpClick     time.Time
 	lastShotClick     time.Time
@@ -118,19 +117,12 @@ type touchPoint struct {
 	y int
 }
 
-type loadedIcon struct {
-	name string
-	img  *ebiten.Image
-}
-
 type geyserListItem struct {
 	text string
 	icon *ebiten.Image
 	w    int
 	h    int
 }
-
-func (g *Game) uiScale() float64 { return uiScale }
 
 func (g *Game) iconSize() int { return uiScaled(HelpIconSize) }
 
@@ -139,10 +131,6 @@ func (g *Game) filterMode() ebiten.Filter {
 		return ebiten.FilterLinear
 	}
 	return ebiten.FilterNearest
-}
-
-func (g *Game) inBounds(x, y int) bool {
-	return x >= 0 && x < g.width && y >= 0 && y < g.height
 }
 
 func drawPlusMinus(dst *ebiten.Image, rect image.Rectangle, minus bool) {

--- a/help.go
+++ b/help.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"image/color"
 	"strings"
-
-	"github.com/hajimehoshi/ebiten/v2"
 )
 
 var helpMessage string
@@ -21,24 +19,6 @@ const (
 )
 
 var errorBorderColor = color.RGBA{R: 244, G: 67, B: 54, A: 255}
-
-var grayColorM = func() ebiten.ColorM {
-	var m ebiten.ColorM
-	const r = 0.299
-	const g = 0.587
-	const b = 0.114
-	m.SetElement(0, 0, r)
-	m.SetElement(0, 1, g)
-	m.SetElement(0, 2, b)
-	m.SetElement(1, 0, r)
-	m.SetElement(1, 1, g)
-	m.SetElement(1, 2, b)
-	m.SetElement(2, 0, r)
-	m.SetElement(2, 1, g)
-	m.SetElement(2, 2, b)
-	m.SetElement(3, 3, 1)
-	return m
-}()
 
 func init() {
 	lines := [][2]string{

--- a/net.go
+++ b/net.go
@@ -18,7 +18,7 @@ func fetchSeedCBOR(coordinate string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/parse.go
+++ b/parse.go
@@ -6,6 +6,10 @@ import (
 )
 
 // parseBiomePaths converts the raw biome path string into structured paths.
+func isNameChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'
+}
+
 func parseBiomePaths(data string) []BiomePath {
 	data = strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(data), "\r", ""), "\n", " ")
 	// Locate biome names followed by a colon without using regular expressions.
@@ -15,7 +19,7 @@ func parseBiomePaths(data string) []BiomePath {
 			start := i - 1
 			for start >= 0 {
 				c := data[start]
-				if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+				if !isNameChar(c) {
 					break
 				}
 				start--

--- a/text_draw.go
+++ b/text_draw.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	//nolint:staticcheck // text package is deprecated but used for compatibility
 	"github.com/hajimehoshi/ebiten/v2/text"
 )
 
@@ -16,15 +17,4 @@ func drawText(dst *ebiten.Image, str string, x, y int, center bool) {
 		x -= w / 2
 	}
 	text.Draw(dst, str, notoFont, x, y+int(notoFont.Metrics().Ascent.Ceil()), color.White)
-}
-
-func drawTextColor(dst *ebiten.Image, str string, x, y int, center bool, clr color.Color) {
-	if notoFont == nil {
-		return
-	}
-	if center {
-		w, _ := textDimensions(str)
-		x -= w / 2
-	}
-	text.Draw(dst, str, notoFont, x, y+int(notoFont.Metrics().Ascent.Ceil()), clr)
 }

--- a/textutil.go
+++ b/textutil.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/hajimehoshi/ebiten/v2/text"
+	"golang.org/x/image/font"
 )
 
 func textDimensions(str string) (int, int) {
@@ -23,9 +23,10 @@ func textDimensions(str string) (int, int) {
 
 	width := 0
 	for _, l := range lines {
-		b := text.BoundString(notoFont, l)
-		if b.Dx() > width {
-			width = b.Dx()
+		b, _ := font.BoundString(notoFont, l)
+		w := (b.Max.X - b.Min.X).Ceil()
+		if w > width {
+			width = w
 		}
 	}
 	lineHeight := notoFont.Metrics().Height.Ceil()

--- a/touch_input.go
+++ b/touch_input.go
@@ -10,7 +10,7 @@ import (
 
 func (g *Game) handleTouchGestures(oldX, oldY float64) {
 	// Touch gestures
-	touchIDs := ebiten.TouchIDs()
+	touchIDs := ebiten.AppendTouchIDs(nil)
 	justPressedIDs := inpututil.AppendJustPressedTouchIDs(nil)
 	if g.ssPending > 0 || g.skipClickTicks > 0 {
 		touchIDs = nil

--- a/ui_scale.go
+++ b/ui_scale.go
@@ -21,6 +21,3 @@ func uiScaled(v int) int {
 func uiScaledF(v float64) float64 {
 	return v * uiScale * getHiDPIScale()
 }
-
-// uiScaleFactor returns the combined UI scale including the HiDPI factor.
-func (g *Game) uiScaleFactor() float64 { return uiScale * getHiDPIScale() }

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -134,7 +134,7 @@ func (g *Game) drawGeyserListScreen(dst *ebiten.Image) bool {
 }
 
 func (g *Game) drawLoadingScreen(dst *ebiten.Image) bool {
-	if !(g.loading || (len(g.biomes) == 0 && g.status != "")) {
+	if !g.loading && (len(g.biomes) != 0 || g.status == "") {
 		return false
 	}
 	dst.Fill(backgroundColor)


### PR DESCRIPTION
## Summary
- clean up unused functions and fields
- handle close errors and minor logic tweaks
- simplify name parsing and touch handling
- update text helpers to use x/image/font
- silence deprecated text import warning

## Testing
- `go test -run=^$ ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688bb9582f1c832aafe7c089fcf4a30a