### PR TITLE
refactor: separate overlay menu drawing

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -429,6 +429,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		}
 
 		g.drawUI(screen)
+		g.drawOverlayMenus(screen)
 	}
 	g.captureScreen(screen)
 

--- a/draw_helpers.go
+++ b/draw_helpers.go
@@ -49,7 +49,9 @@ func (g *Game) drawUI(screen *ebiten.Image) {
 		ty := g.height - panelH - uiScaled(30)
 		g.drawInfoPanel(screen, g.infoText, g.infoIcon, tx, ty)
 	}
+}
 
+func (g *Game) drawOverlayMenus(screen *ebiten.Image) {
 	if g.showShotMenu {
 		g.drawScreenshotMenu(screen)
 	}


### PR DESCRIPTION
## Summary
- Extract overlay menu rendering into `drawOverlayMenus`
- Call `drawOverlayMenus` after `drawUI` so menus render on top

## Testing
- `scripts/install_deps.sh`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bcd431af8832a97962ac23ef3fcb6