### PR TITLE
Switch to JSON seed data and update endpoints

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -2,7 +2,7 @@
 
 This project depends heavily on work from the [Maps Not Included](https://mapsnotincluded.org) community.
 
-* Seed data is retrieved at runtime from `https://ingest.mapsnotincluded.org`.
+* Seed data is retrieved at runtime from `https://oni-worlds.stefanoltmann.de` with a fallback to `https://data.mapsnotincluded.org/oni-worlds/`.
 * Image assets originate from the [oni-seed-browser](https://github.com/MapsNotIncluded/oni-seed-browser) repository.
 
 Many thanks to the Maps Not Included developers for making these resources available.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Oni-SeedView is a small viewer for **Oxygen Not Included** seed data. It fetches
 
 - ~4.6k lines of Go code
 - Engine: Ebiten 2
-- Major libraries: `fxamacker/cbor`, `golang.org/x/image`
+- Major libraries: `golang.org/x/image`
 
 ## Quick Start
 

--- a/const.go
+++ b/const.go
@@ -9,8 +9,9 @@ import (
 
 const (
 	ClientVersion    = "v0.0.9-2507061929"
-	BaseURL          = "https://ingest.mapsnotincluded.org/coordinate/"
-	AcceptCBORHeader = "application/cbor"
+	BaseURL          = "https://oni-worlds.stefanoltmann.de/"
+	FallbackBaseURL  = "https://data.mapsnotincluded.org/oni-worlds/"
+	AcceptJSONHeader = "application/json"
 	PanSpeed         = 15
 	// CameraMargin controls how far the world can be panned
 	// beyond the visible screen in pixels.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module oni-view
 go 1.24.3
 
 require (
-	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/hajimehoshi/ebiten/v2 v2.8.8
 	golang.org/x/image v0.20.0
 )
@@ -13,7 +12,6 @@ require (
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj
 github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
 github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
-github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0 h1:0DISQM/rseKIJhdF29AkhvdzIULqNIIlXAGWit4ez1Q=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0/go.mod h1:8gLqGatKVu0pwcNCJguW3Igg9WQqVXF0zg/RvrGQWyg=
 github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
@@ -14,8 +12,6 @@ github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
-github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
-github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/image v0.20.0 h1:7cVCUjQwfL18gyBJOmYvptfSHS8Fb3YUDtfLIZ7Nbpw=
 golang.org/x/image v0.20.0/go.mod h1:0a88To4CYVBAHp5FXJm8o7QbUl37Vd85ply1vyD8auM=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=

--- a/html/index.html
+++ b/html/index.html
@@ -118,7 +118,8 @@
     <div id="message"></div>
   </div>
   <script>
-  const baseURL = "https://ingest.mapsnotincluded.org/coordinate/";
+  const primaryURL = "https://oni-worlds.stefanoltmann.de/";
+  const fallbackURL = "https://data.mapsnotincluded.org/oni-worlds/";
   function seedFromURL() {
     const search = window.location.search.slice(1);
     for (const part of search.split('&')) {
@@ -160,7 +161,15 @@
     if (!seed) return;
     document.getElementById('message').textContent = 'Checking…';
     try {
-      const resp = await fetch(baseURL + encodeURIComponent(seed));
+      let resp;
+      try {
+        resp = await fetch(primaryURL + encodeURIComponent(seed), { headers: { 'Accept': 'application/json' } });
+        if (!resp.ok) {
+          throw new Error('primary failed');
+        }
+      } catch (_) {
+        resp = await fetch(fallbackURL + encodeURIComponent(seed), { headers: { 'Accept': 'application/json' } });
+      }
       if (resp.ok) {
         if (resp.body && typeof resp.body.cancel === 'function') {
           resp.body.cancel();

--- a/layout.md
+++ b/layout.md
@@ -23,8 +23,8 @@ This document explains how the Oni-SeedView repository is organized. It expands 
 - `assets.go` – Loads and caches embedded images. Also converts filenames to the camel case used by some assets.
 - `colors.go` and `const.go` – Color definitions and user‑interface constants.
 - `parse.go` – Converts biome path strings into coordinate lists.
-- `types.go` – Data structures for geysers, POIs and asteroids used when decoding CBOR seed data.
-- `net.go` – Performs HTTP requests to `https://ingest.mapsnotincluded.org` and decodes CBOR via `github.com/fxamacker/cbor/v2`.
+- `types.go` – Data structures for geysers, POIs and asteroids used when decoding JSON seed data.
+- `net.go` – Performs HTTP requests to `https://oni-worlds.stefanoltmann.de` with a fallback to `https://data.mapsnotincluded.org/oni-worlds/` and decodes JSON via Go's `encoding/json`.
 - `fonts.go` – Handles font loading and size adjustments.
 - `text_draw.go`, `textutil.go` – Text rendering utilities.
 - `touch_input.go`, `mobile_detect.go` – Touch gesture handling and simple mobile detection.
@@ -32,7 +32,7 @@ This document explains how the Oni-SeedView repository is organized. It expands 
 
 ## Data Flow and State
 
-Seed information is downloaded by `fetchSeedCBOR` in `net.go` and decoded to the
+Seed information is downloaded by `fetchSeedJSON` in `net.go` and decoded to the
 `SeedData` struct via `decodeSeed`. Each `Asteroid` entry stores geysers, POIs
 and biome polygon paths. Functions in `parse.go` convert those paths into
 coordinate lists. The resulting slices are stored on the `Game` struct defined

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 }
 
 func loadGameData(game *Game, coord, asteroidID string) {
-	cborData, err := fetchSeedCBOR(coord)
+	jsonData, err := fetchSeedJSON(coord)
 	if err != nil {
 		game.status = "Error: " + err.Error()
 		game.statusError = false
@@ -85,7 +85,7 @@ func loadGameData(game *Game, coord, asteroidID string) {
 		game.loading = false
 		return
 	}
-	seed, err := decodeSeed(cborData)
+	seed, err := decodeSeed(jsonData)
 	game.asteroids = seed.Asteroids
 	if err != nil {
 		game.status = "Error: " + err.Error()

--- a/net.go
+++ b/net.go
@@ -1,37 +1,50 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/fxamacker/cbor/v2"
 )
 
-// fetchSeedCBOR retrieves the seed data in CBOR format for a given coordinate.
-func fetchSeedCBOR(coordinate string) ([]byte, error) {
-	url := BaseURL + coordinate
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Set("Accept", AcceptCBORHeader)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %v", err)
+// fetchSeedJSON retrieves the seed data in JSON format for a given coordinate.
+// It first tries the primary URL and falls back to the secondary if needed.
+func fetchSeedJSON(coordinate string) ([]byte, error) {
+	urls := []string{
+		BaseURL + coordinate,
+		FallbackBaseURL + coordinate,
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+	var lastErr error
+	for _, url := range urls {
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Accept", AcceptJSONHeader)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %v", err)
+			continue
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("read failed: %v", err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+			continue
+		}
+		return body, nil
 	}
-	return io.ReadAll(resp.Body)
+	return nil, lastErr
 }
 
-// decodeSeed parses the CBOR seed data into SeedData.
-func decodeSeed(cborData []byte) (*SeedData, error) {
+// decodeSeed parses the JSON seed data into SeedData.
+func decodeSeed(jsonData []byte) (*SeedData, error) {
 	var seed SeedData
-	if err := cbor.Unmarshal(cborData, &seed); err != nil {
-		return nil, fmt.Errorf("CBOR decode failed: %v", err)
+	if err := json.Unmarshal(jsonData, &seed); err != nil {
+		return nil, fmt.Errorf("JSON decode failed: %v", err)
 	}
 	return &seed, nil
 }


### PR DESCRIPTION
## Summary
- Fetch seed data as JSON from `oni-worlds.stefanoltmann.de` with fallback to `data.mapsnotincluded.org`.
- Decode JSON instead of CBOR and drop CBOR dependency.
- Update web assets and docs to reference new endpoints.

## Testing
- `gofmt -w *.go`
- `scripts/install_deps.sh`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6a5cd96b4832aa04cf3eca98448d4