### PR TITLE
Use structured biome paths

### DIFF
--- a/asteroid_menu.go
+++ b/asteroid_menu.go
@@ -206,7 +206,7 @@ func (g *Game) loadAsteroid(ast Asteroid) {
 	g.legendColors = nil
 	g.selectedItem = -1
 	g.itemScroll = 0
-	bps := parseBiomePaths(ast.BiomePaths)
+	bps := ast.BiomePaths.Paths
 	g.geysers = ast.Geysers
 	g.pois = ast.POIs
 	g.biomes = bps

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func loadGameData(game *Game, coord, asteroidID string) {
 	game.selectedItem = -1
 	game.itemScroll = 0
 	game.asteroidID = ast.ID
-	bps := parseBiomePaths(ast.BiomePaths)
+	bps := ast.BiomePaths.Paths
 	game.geysers = ast.Geysers
 	game.pois = ast.POIs
 	game.biomes = bps

--- a/net_test.go
+++ b/net_test.go
@@ -88,4 +88,12 @@ func TestDecodeSeedProto(t *testing.T) {
 	if len(a.BiomePaths.Paths) != 1 || a.BiomePaths.Paths[0].Name != "B1" {
 		t.Fatalf("unexpected biome paths: %+v", a.BiomePaths)
 	}
+	bp := a.BiomePaths.Paths[0]
+	if len(bp.Polygons) != 1 || len(bp.Polygons[0]) != 2 {
+		t.Fatalf("unexpected polygon count: %+v", bp.Polygons)
+	}
+	p0 := bp.Polygons[0]
+	if p0[0] != (Point{X: 1, Y: 2}) || p0[1] != (Point{X: 3, Y: 4}) {
+		t.Fatalf("unexpected polygon points: %+v", p0)
+	}
 }

--- a/parse.go
+++ b/parse.go
@@ -1,6 +1,0 @@
-package main
-
-// parseBiomePaths returns the structured biome paths as-is.
-func parseBiomePaths(data BiomePathsCompact) []BiomePath {
-	return data.Paths
-}


### PR DESCRIPTION
## Summary
- remove legacy `parseBiomePaths` helper
- read biome polygons directly from structured `BiomePathsCompact`
- test polygon conversion

## Testing
- `xvfb-run -a go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1891ac9b4832aaf459463db2207a1