### PR TITLE
Use gzip protobuf endpoint

### DIFF
--- a/const.go
+++ b/const.go
@@ -11,7 +11,7 @@ const (
 	ClientVersion     = "v0.1.0-2508202308"
 	BaseURL           = "https://oni-worlds.stefanoltmann.de/"
 	FallbackBaseURL   = "https://data.mapsnotincluded.org/oni-worlds/"
-	ProtoBaseURL      = "https://oni-data.stefanoltmann.de/"
+	ProtoBaseURL      = "https://oni-data.stefanoltmann.de/COORDINATE/"
 	AcceptJSONHeader  = "application/json"
 	AcceptProtoHeader = "application/protobuf"
 	GzipEncoding      = "gzip"

--- a/net.go
+++ b/net.go
@@ -52,6 +52,7 @@ func fetchSeedProto(coordinate string) ([]byte, error) {
 	url := seedProtoBaseURL + coordinate
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Accept", AcceptProtoHeader)
+	req.Header.Set("Accept-Encoding", GzipEncoding)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/net_test.go
+++ b/net_test.go
@@ -16,6 +16,9 @@ func TestFetchSeedProtoDecompressesGzip(t *testing.T) {
 		if got := r.Header.Get("Accept"); got != AcceptProtoHeader {
 			t.Fatalf("unexpected Accept header: %s", got)
 		}
+		if got := r.Header.Get("Accept-Encoding"); got != GzipEncoding {
+			t.Fatalf("unexpected Accept-Encoding header: %s", got)
+		}
 		w.Header().Set("Content-Encoding", GzipEncoding)
 		gz := gzip.NewWriter(w)
 		gz.Write([]byte("hello"))


### PR DESCRIPTION
## Summary
- target oni-data protobuf endpoint at new /COORDINATE path
- request gzip-encoded protobuf data and test for header

## Testing
- `gofmt -w const.go net.go net_test.go`
- `gofmt -w *.go`
- `scripts/install_deps.sh`
- `xvfb-run -a go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c18ce4fce8832aa883e5bb2aa192ac