### PR TITLE
Remove JSON seed fetching and update data URL

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -2,7 +2,7 @@
 
 This project depends heavily on work from the [Maps Not Included](https://mapsnotincluded.org) community.
 
-* Seed data is retrieved at runtime from `https://oni-worlds.stefanoltmann.de` with a fallback to `https://data.mapsnotincluded.org/oni-worlds/`.
+* Seed data is retrieved at runtime from `https://oni-data.stefanoltmann.de/COORDINATE/`.
 * Image assets originate from the [oni-seed-browser](https://github.com/MapsNotIncluded/oni-seed-browser) repository.
 
 Many thanks to the Maps Not Included developers for making these resources available.

--- a/const.go
+++ b/const.go
@@ -9,10 +9,7 @@ import (
 
 const (
 	ClientVersion     = "v0.1.0-2508202308"
-	BaseURL           = "https://oni-worlds.stefanoltmann.de/"
-	FallbackBaseURL   = "https://data.mapsnotincluded.org/oni-worlds/"
 	ProtoBaseURL      = "https://oni-data.stefanoltmann.de/COORDINATE/"
-	AcceptJSONHeader  = "application/json"
 	AcceptProtoHeader = "application/protobuf"
 	GzipEncoding      = "gzip"
 	PanSpeed          = 15

--- a/html/index.html
+++ b/html/index.html
@@ -118,8 +118,7 @@
     <div id="message"></div>
   </div>
   <script>
-  const primaryURL = "https://oni-worlds.stefanoltmann.de/";
-  const fallbackURL = "https://data.mapsnotincluded.org/oni-worlds/";
+  const protoURL = "https://oni-data.stefanoltmann.de/COORDINATE/";
   function seedFromURL() {
     const search = window.location.search.slice(1);
     for (const part of search.split('&')) {
@@ -161,15 +160,8 @@
     if (!seed) return;
     document.getElementById('message').textContent = 'Checking…';
     try {
-      let resp;
-      try {
-        resp = await fetch(primaryURL + encodeURIComponent(seed), { headers: { 'Accept': 'application/json' } });
-        if (!resp.ok) {
-          throw new Error('primary failed');
-        }
-      } catch (_) {
-        resp = await fetch(fallbackURL + encodeURIComponent(seed), { headers: { 'Accept': 'application/json' } });
-      }
+      const url = protoURL.replace('COORDINATE', encodeURIComponent(seed));
+      const resp = await fetch(url, { headers: { 'Accept': 'application/protobuf', 'Accept-Encoding': 'gzip' } });
       if (resp.ok) {
         if (resp.body && typeof resp.body.cancel === 'function') {
           resp.body.cancel();

--- a/layout.md
+++ b/layout.md
@@ -23,8 +23,8 @@ This document explains how the Oni-SeedView repository is organized. It expands 
 - `assets.go` – Loads and caches embedded images. Also converts filenames to the camel case used by some assets.
 - `colors.go` and `const.go` – Color definitions and user‑interface constants.
 - `parse.go` – Converts biome path strings into coordinate lists.
-- `types.go` – Data structures for geysers, POIs and asteroids used when decoding JSON seed data.
-- `net.go` – Performs HTTP requests to `https://oni-worlds.stefanoltmann.de` with a fallback to `https://data.mapsnotincluded.org/oni-worlds/` and decodes JSON via Go's `encoding/json`.
+- `types.go` – Data structures for geysers, POIs and asteroids.
+- `net.go` – Performs HTTP requests to `https://oni-data.stefanoltmann.de/COORDINATE/` and decodes protobuf data via Go's `google.golang.org/protobuf`.
 - `fonts.go` – Handles font loading and size adjustments.
 - `text_draw.go`, `textutil.go` – Text rendering utilities.
 - `touch_input.go`, `mobile_detect.go` – Touch gesture handling and simple mobile detection.
@@ -32,8 +32,8 @@ This document explains how the Oni-SeedView repository is organized. It expands 
 
 ## Data Flow and State
 
-Seed information is downloaded by `fetchSeedJSON` in `net.go` and decoded to the
-`SeedData` struct via `decodeSeed`. Each `Asteroid` entry stores geysers, POIs
+Seed information is downloaded by `fetchSeedProto` in `net.go` and decoded to the
+`SeedData` struct via `decodeSeedProto`. Each `Asteroid` entry stores geysers, POIs
 and biome polygon paths. Functions in `parse.go` convert those paths into
 coordinate lists. The resulting slices are stored on the `Game` struct defined
 in `game_helpers.go` along with runtime assets, camera coordinates and menu

--- a/main.go
+++ b/main.go
@@ -78,27 +78,20 @@ func main() {
 
 func loadGameData(game *Game, coord, asteroidID string) {
 	data, err := fetchSeedProto(coord)
-	var seed *SeedData
-	if err == nil {
-		seed, err = decodeSeedProto(data)
-	}
 	if err != nil {
-		jsonData, jerr := fetchSeedJSON(coord)
-		if jerr != nil {
-			game.status = "Error: " + jerr.Error()
-			game.statusError = false
-			game.needsRedraw = true
-			game.loading = false
-			return
-		}
-		seed, err = decodeSeed(jsonData)
-		if err != nil {
-			game.status = "Error: " + err.Error()
-			game.statusError = false
-			game.needsRedraw = true
-			game.loading = false
-			return
-		}
+		game.status = "Error: " + err.Error()
+		game.statusError = false
+		game.needsRedraw = true
+		game.loading = false
+		return
+	}
+	seed, err := decodeSeedProto(data)
+	if err != nil {
+		game.status = "Error: " + err.Error()
+		game.statusError = false
+		game.needsRedraw = true
+		game.loading = false
+		return
 	}
 	game.asteroids = seed.Asteroids
 	astIdxSel := 0

--- a/net_test.go
+++ b/net_test.go
@@ -28,7 +28,7 @@ func TestFetchSeedProtoDecompressesGzip(t *testing.T) {
 	defer srv.Close()
 
 	old := seedProtoBaseURL
-	seedProtoBaseURL = srv.URL + "/"
+	seedProtoBaseURL = srv.URL + "/COORDINATE/"
 	defer func() { seedProtoBaseURL = old }()
 
 	body, err := fetchSeedProto("test")

--- a/short_names.go
+++ b/short_names.go
@@ -2,8 +2,8 @@ package main
 
 // shortNameTables holds mappings of item IDs to shortened labels.
 type shortNameTables struct {
-	Geysers map[string]string `json:"geysers"`
-	POIs    map[string]string `json:"pois"`
+	Geysers map[string]string
+	POIs    map[string]string
 }
 
 var shortNames = shortNameTables{

--- a/types.go
+++ b/types.go
@@ -30,26 +30,26 @@ type BiomePath struct {
 }
 
 type BiomePathsCompact struct {
-	Paths []BiomePath `json:"paths"`
+	Paths []BiomePath
 }
 
 type Asteroid struct {
-	ID         string            `json:"id"`
-	SizeX      int               `json:"sizeX"`
-	SizeY      int               `json:"sizeY"`
-	Geysers    []Geyser          `json:"geysers"`
-	POIs       []PointOfInterest `json:"pointsOfInterest"`
-	BiomePaths BiomePathsCompact `json:"biomePaths"`
+	ID         string
+	SizeX      int
+	SizeY      int
+	Geysers    []Geyser
+	POIs       []PointOfInterest
+	BiomePaths BiomePathsCompact
 }
 
 type SeedData struct {
-	Asteroids []Asteroid `json:"asteroids"`
+	Asteroids []Asteroid
 }
 
 type nameTables struct {
-	Biomes  map[string]string `json:"biomes"`
-	Geysers map[string]string `json:"geysers"`
-	POIs    map[string]string `json:"pois"`
+	Biomes  map[string]string
+	Geysers map[string]string
+	POIs    map[string]string
 }
 
 var names = nameTables{


### PR DESCRIPTION
## Summary
- switch to new coordinate-based protobuf endpoint and drop JSON URL constants
- remove JSON fetch/decoding and rely solely on protobuf data
- update web UI and docs to use the new URL format
- clean up remaining JSON struct tags

## Testing
- `gofmt -w *.go`
- `xvfb-run go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c18f32473c832aa981e742850cba0c