### PR TITLE
Fix seed query URL construction

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -2,7 +2,7 @@
 
 This project depends heavily on work from the [Maps Not Included](https://mapsnotincluded.org) community.
 
-* Seed data is retrieved at runtime from `https://oni-data.stefanoltmann.de/COORDINATE/`.
+* Seed data is retrieved at runtime from `https://oni-data.stefanoltmann.de/COORDINATE`.
 * Image assets originate from the [oni-seed-browser](https://github.com/MapsNotIncluded/oni-seed-browser) repository.
 
 Many thanks to the Maps Not Included developers for making these resources available.

--- a/html/index.html
+++ b/html/index.html
@@ -118,7 +118,7 @@
     <div id="message"></div>
   </div>
   <script>
-  const protoURL = "https://oni-data.stefanoltmann.de/COORDINATE/";
+  const protoURL = "https://oni-data.stefanoltmann.de/";
   function seedFromURL() {
     const search = window.location.search.slice(1);
     for (const part of search.split('&')) {
@@ -160,7 +160,7 @@
     if (!seed) return;
     document.getElementById('message').textContent = 'Checking…';
     try {
-      const url = protoURL.replace('COORDINATE', encodeURIComponent(seed));
+      const url = protoURL + encodeURIComponent(seed);
       const resp = await fetch(url, { headers: { 'Accept': 'application/protobuf', 'Accept-Encoding': 'gzip' } });
       if (resp.ok) {
         if (resp.body && typeof resp.body.cancel === 'function') {

--- a/layout.md
+++ b/layout.md
@@ -24,7 +24,7 @@ This document explains how the Oni-SeedView repository is organized. It expands 
 - `colors.go` and `const.go` – Color definitions and user‑interface constants.
 - `parse.go` – Converts biome path strings into coordinate lists.
 - `types.go` – Data structures for geysers, POIs and asteroids.
-- `net.go` – Performs HTTP requests to `https://oni-data.stefanoltmann.de/COORDINATE/` and decodes protobuf data via Go's `google.golang.org/protobuf`.
+- `net.go` – Performs HTTP requests to `https://oni-data.stefanoltmann.de/COORDINATE` and decodes protobuf data via Go's `google.golang.org/protobuf`.
 - `fonts.go` – Handles font loading and size adjustments.
 - `text_draw.go`, `textutil.go` – Text rendering utilities.
 - `touch_input.go`, `mobile_detect.go` – Touch gesture handling and simple mobile detection.

--- a/net.go
+++ b/net.go
@@ -16,7 +16,8 @@ var seedProtoBaseURL = ProtoBaseURL
 // fetchSeedProto retrieves the seed data in protobuf format for a given coordinate.
 // It requests the protobuf endpoint and transparently decompresses gzip-encoded responses.
 func fetchSeedProto(coordinate string) ([]byte, error) {
-	url := strings.Replace(seedProtoBaseURL, "COORDINATE", coordinate, 1)
+	base := strings.TrimSuffix(seedProtoBaseURL, "/")
+	url := base + "/" + coordinate
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Accept", AcceptProtoHeader)
 	req.Header.Set("Accept-Encoding", GzipEncoding)

--- a/net_test.go
+++ b/net_test.go
@@ -12,7 +12,9 @@ import (
 
 // TestFetchSeedProtoDecompressesGzip verifies that fetchSeedProto handles gzip responses.
 func TestFetchSeedProtoDecompressesGzip(t *testing.T) {
+	var reqPath string
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		reqPath = r.URL.Path
 		if got := r.Header.Get("Accept"); got != AcceptProtoHeader {
 			t.Fatalf("unexpected Accept header: %s", got)
 		}
@@ -28,7 +30,7 @@ func TestFetchSeedProtoDecompressesGzip(t *testing.T) {
 	defer srv.Close()
 
 	old := seedProtoBaseURL
-	seedProtoBaseURL = srv.URL + "/COORDINATE/"
+	seedProtoBaseURL = srv.URL + "/"
 	defer func() { seedProtoBaseURL = old }()
 
 	body, err := fetchSeedProto("test")
@@ -37,6 +39,9 @@ func TestFetchSeedProtoDecompressesGzip(t *testing.T) {
 	}
 	if string(body) != "hello" {
 		t.Fatalf("unexpected body: %s", body)
+	}
+	if reqPath != "/test" {
+		t.Fatalf("unexpected path: %s", reqPath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Build seed URL by appending coordinate to base instead of replacing a placeholder
- Adjust tests to verify correct path

## Testing
- `xvfb-run go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c192b7f314832a87eeb98ab5a2763c