### PR TITLE
Handle numeric geyser IDs

### DIFF
--- a/data/pb/seed.pb.go
+++ b/data/pb/seed.pb.go
@@ -23,7 +23,7 @@ const (
 
 type Geyser struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
-	Id                    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id                    int32                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	X                     int32                  `protobuf:"varint,2,opt,name=x,proto3" json:"x,omitempty"`
 	Y                     int32                  `protobuf:"varint,3,opt,name=y,proto3" json:"y,omitempty"`
 	EmitRate              int32                  `protobuf:"varint,4,opt,name=emitRate,proto3" json:"emitRate,omitempty"`
@@ -66,11 +66,11 @@ func (*Geyser) Descriptor() ([]byte, []int) {
 	return file_data_pb_seed_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *Geyser) GetId() string {
+func (x *Geyser) GetId() int32 {
 	if x != nil {
 		return x.Id
 	}
-	return ""
+	return 0
 }
 
 func (x *Geyser) GetX() int32 {
@@ -347,7 +347,7 @@ const file_data_pb_seed_proto_rawDesc = "" +
 	"\n" +
 	"\x12data/pb/seed.proto\x12\x06seedpb\"\x9a\x02\n" +
 	"\x06Geyser\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\f\n" +
+	"\x02id\x18\x01 \x01(\x05R\x02id\x12\f\n" +
 	"\x01x\x18\x02 \x01(\x05R\x01x\x12\f\n" +
 	"\x01y\x18\x03 \x01(\x05R\x01y\x12\x1a\n" +
 	"\bemitRate\x18\x04 \x01(\x05R\bemitRate\x12 \n" +

--- a/data/pb/seed.proto
+++ b/data/pb/seed.proto
@@ -3,7 +3,7 @@ package seedpb;
 option go_package = "oni-view/data/pb;seedpb";
 
 message Geyser {
-  string id = 1;
+  int32 id = 1;
   int32 x = 2;
   int32 y = 3;
   int32 emitRate = 4;

--- a/net.go
+++ b/net.go
@@ -14,6 +14,68 @@ import (
 
 var seedProtoBaseURL = ProtoBaseURL
 
+// geyserTypeFromID maps numeric geyser IDs to their string descriptors.
+func geyserTypeFromID(id int32) string {
+	switch id {
+	case 0:
+		return "steam"
+	case 1:
+		return "hot_hydrogen"
+	case 2:
+		return "methane"
+	case 3:
+		return "chlorine_gas"
+	case 4:
+		return "chlorine_gas_cool"
+	case 5:
+		return "hot_steam"
+	case 6:
+		return "hot_co2"
+	case 7:
+		return "hot_po2"
+	case 8:
+		return "slimy_po2"
+	case 9:
+		return "hot_water"
+	case 10:
+		return "slush_water"
+	case 11:
+		return "filthy_water"
+	case 12:
+		return "slush_salt_water"
+	case 13:
+		return "salt_water"
+	case 14:
+		return "liquid_co2"
+	case 15:
+		return "oil_drip"
+	case 16:
+		return "liquid_sulfur"
+	case 17:
+		return "molten_iron"
+	case 18:
+		return "molten_copper"
+	case 19:
+		return "molten_gold"
+	case 20:
+		return "molten_aluminum"
+	case 21:
+		return "molten_cobalt"
+	case 22:
+		return "molten_tungsten"
+	case 23:
+		return "molten_niobium"
+	case 24:
+		return "big_volcano"
+	case 25:
+		return "small_volcano"
+	case 26:
+		return "OilWell"
+	default:
+		return ""
+	}
+}
+
 // fetchSeedProto retrieves the seed data in protobuf format for a given coordinate.
 // It requests the protobuf endpoint and transparently decompresses gzip-encoded responses.
 func fetchSeedProto(coordinate string) ([]byte, error) {
@@ -63,7 +125,7 @@ func decodeSeedProto(protoData []byte) (*SeedData, error) {
 		}
 		for _, g := range a.Geysers {
 			ast.Geysers = append(ast.Geysers, Geyser{
-				ID:             g.Id,
+				ID:             geyserTypeFromID(g.Id),
 				X:              int(g.X),
 				Y:              int(g.Y),
 				EmitRate:       float64(g.EmitRate),

--- a/net_test.go
+++ b/net_test.go
@@ -53,7 +53,7 @@ func TestDecodeSeedProto(t *testing.T) {
 				Id:               "A1",
 				SizeX:            10,
 				SizeY:            20,
-				Geysers:          []*seedpb.Geyser{{Id: "g1", X: 1, Y: 2}},
+				Geysers:          []*seedpb.Geyser{{Id: 0, X: 1, Y: 2}},
 				PointsOfInterest: []*seedpb.PointOfInterest{{Id: "p1", X: 3, Y: 4}},
 				BiomePaths:       "3:1 2 2 2",
 			},
@@ -74,7 +74,7 @@ func TestDecodeSeedProto(t *testing.T) {
 	if a.ID != "A1" || a.SizeX != 10 || a.SizeY != 20 {
 		t.Fatalf("unexpected asteroid: %+v", a)
 	}
-	if len(a.Geysers) != 1 || a.Geysers[0].ID != "g1" {
+	if len(a.Geysers) != 1 || a.Geysers[0].ID != "steam" {
 		t.Fatalf("unexpected geysers: %+v", a.Geysers)
 	}
 	if len(a.POIs) != 1 || a.POIs[0].ID != "p1" {


### PR DESCRIPTION
## Summary
- Parse numeric geyser IDs from backend protobuf
- Map geyser ID numbers to type strings so icons render
- Update tests for numeric ID handling

## Testing
- `./scripts/install_deps.sh` (fails: PS1 unbound variable)
- `go test ./...` (fails: GLFW DISPLAY environment variable missing)


------
https://chatgpt.com/codex/tasks/task_e_68c19a6c9ddc832a959eab3e5c594160